### PR TITLE
Add message API for scenarios

### DIFF
--- a/ball_example/README.md
+++ b/ball_example/README.md
@@ -1,0 +1,44 @@
+# Ball Example
+
+This directory contains a simple Flask application that tracks balls and controls a PlotClock device.
+
+## Running
+
+```bash
+python app.py
+```
+
+The server listens on `http://localhost:8000` by default.
+
+## API
+
+### `POST /start_scenario`
+Enables the currently selected scenario.
+
+### `POST /connect_pico`
+Establishes serial communication with the PlotClock.
+
+### `POST /send_cmd`
+Sends a raw command string to the PlotClock. Example:
+
+```bash
+curl -X POST http://localhost:8000/send_cmd \
+     -H 'Content-Type: application/json' \
+     -d '{"cmd": "setxy 10 10"}'
+```
+
+### `POST /send_message`
+Dispatches an arbitrary JSON payload to the active scenario. The scenario must implement
+`process_message(data)` to handle the message.
+
+```bash
+curl -X POST http://localhost:8000/send_message \
+     -H 'Content-Type: application/json' \
+     -d '{"type": "greet", "value": "hello"}'
+```
+
+If the scenario does not provide a custom response, the endpoint returns:
+
+```json
+{"status": "ok"}
+```

--- a/ball_example/app.py
+++ b/ball_example/app.py
@@ -161,6 +161,24 @@ def send_cmd():
             return jsonify({'status': 'error', 'message': str(e)}), 500
 
 
+@app.route('/send_message', methods=['POST'])
+def send_message():
+    """Dispatch an arbitrary JSON payload to the active scenario."""
+    if _current_scenario is None:
+        return jsonify({'status': 'error', 'message': 'no active scenario'}), 400
+
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({'status': 'error', 'message': 'invalid JSON payload'}), 400
+
+    try:
+        resp = _current_scenario.process_message(data)
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 500
+
+    return jsonify(resp or {'status': 'ok'})
+
+
 if __name__ == '__main__':
     try:
         camera.start()

--- a/ball_example/scenarios.py
+++ b/ball_example/scenarios.py
@@ -21,6 +21,15 @@ class Scenario:
     def get_extra_labels(self):
         return None
 
+    def process_message(self, data: Dict[str, Any]):
+        """Handle an incoming message for the scenario.
+
+        Subclasses may override this to implement custom behaviour. The
+        default implementation simply returns ``None`` which results in a
+        generic ``{"status": "ok"}`` response from the API.
+        """
+        return None
+
 
 class BallAttacker(Scenario):
     """


### PR DESCRIPTION
## Summary
- add `/send_message` endpoint to forward payloads to active scenario
- implement default `Scenario.process_message`
- document API usage and message example

## Testing
- `python -m py_compile ball_example/app.py ball_example/scenarios.py`

------
https://chatgpt.com/codex/tasks/task_e_6846e92406a083289266e78e58939dd0