### PR TITLE
Support dependency injection for client scenarios

### DIFF
--- a/ball_example/app.py
+++ b/ball_example/app.py
@@ -89,7 +89,7 @@ def load_scenario_route():
     if not path:
         return jsonify({"status": "error", "message": "no path provided"}), 400
     try:
-        _current_scenario = load_scenario(path)
+        _current_scenario = load_scenario(path, plotclock, frame_size)
         scenario_enabled = False
         return jsonify({"status": "ok"})
     except ScenarioLoadError as e:

--- a/ball_example/scenario_loader.py
+++ b/ball_example/scenario_loader.py
@@ -18,11 +18,12 @@ class ScenarioLoadError(Exception):
     pass
 
 
-def load_scenario(path: str) -> Scenario:
-    """Load a client scenario from a Python file.
+def load_scenario(path: str, *args: Any, **kwargs: Any) -> Scenario:
+    """Load a client scenario from ``path`` and instantiate it.
 
-    The module must define a ``ClientScenario`` class derived from
-    :class:`ball_example.scenarios.Scenario`.
+    The Python file must define a ``ClientScenario`` class derived from
+    :class:`ball_example.scenarios.Scenario`. Any extra ``args`` and
+    ``kwargs`` are passed to the constructor of ``ClientScenario``.
     """
     spec = importlib.util.spec_from_file_location("client_module", path)
     if spec is None or spec.loader is None:
@@ -40,6 +41,6 @@ def load_scenario(path: str) -> Scenario:
     if not issubclass(cls, Scenario):
         raise ScenarioLoadError("ClientScenario must subclass Scenario")
     try:
-        return cls()
+        return cls(*args, **kwargs)
     except Exception as e:
         raise ScenarioLoadError(f"Could not instantiate ClientScenario: {e}")

--- a/examples/standing_hitter_client.py
+++ b/examples/standing_hitter_client.py
@@ -1,9 +1,8 @@
 """Client scenario replicating the built-in StandingBallHitter."""
 
-from ball_example.app import plotclock, frame_size
 from ball_example.scenarios import StandingBallHitter, BallReflector
 
 
 class ClientScenario(BallReflector):
-    def __init__(self):
+    def __init__(self, plotclock, frame_size):
         super().__init__(plotclock, frame_size)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -26,6 +26,8 @@ def test_load_scenario_and_message(tmp_path):
     scenario_code = (
         "from ball_example.scenarios import Scenario\n"
         "class ClientScenario(Scenario):\n"
+        "    def __init__(self, plotclock, frame_size):\n"
+        "        pass\n"
         "    def update(self, d): pass\n"
         "    def process_message(self, m):\n"
         "        self.last = m\n"


### PR DESCRIPTION
## Summary
- modify `load_scenario` to pass arguments to `ClientScenario`
- inject `plotclock` and `frame_size` when loading user scenarios
- update client example for new API
- adjust test scenario accordingly

## Testing
- `pytest -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68498cbbf17483289ecca88377ce9eac