### PR TITLE
Refactor image pipelines with base class

### DIFF
--- a/ball_example/pipelines.py
+++ b/ball_example/pipelines.py
@@ -8,16 +8,16 @@ from .detectors import compute_color_mask
 from .trackers import DETECTION_SCALE
 
 
-class RawImagePipeline:
-    """Capture raw frames from a camera in a background thread."""
+class BasePipeline:
+    """Common thread management and frame storage for pipelines."""
 
-    def __init__(self, camera: Camera):
-        self.camera = camera
+    def __init__(self) -> None:
         self.frame: Optional[np.ndarray] = None
         self.lock = threading.Lock()
         self.running = False
         self.thread: Optional[threading.Thread] = None
 
+    # ------------------------------------------------------------------
     def start(self) -> None:
         if self.running:
             return
@@ -25,64 +25,70 @@ class RawImagePipeline:
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
 
+    # ------------------------------------------------------------------
     def _run(self) -> None:
         while self.running:
-            grabbed, frame = self.camera.read()
-            if not grabbed:
+            frame = self.process_frame()
+            if frame is None:
                 time.sleep(0.01)
                 continue
             with self.lock:
                 self.frame = frame
 
+    # ------------------------------------------------------------------
     def stop(self) -> None:
         self.running = False
         if self.thread:
             self.thread.join()
 
-    def get_raw_frame(self) -> Optional[np.ndarray]:
+    # ------------------------------------------------------------------
+    def process_frame(self) -> Optional[np.ndarray]:
+        """Produce the next frame for the pipeline."""
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    def get_frame(self) -> Optional[np.ndarray]:
         with self.lock:
             return None if self.frame is None else self.frame.copy()
 
 
-class MaskedImagePipeline:
+class RawImagePipeline(BasePipeline):
+    """Capture raw frames from a camera in a background thread."""
+
+    def __init__(self, camera: Camera):
+        super().__init__()
+        self.camera = camera
+
+    def process_frame(self) -> Optional[np.ndarray]:
+        grabbed, frame = self.camera.read()
+        if not grabbed:
+            return None
+        return frame
+
+    def get_raw_frame(self) -> Optional[np.ndarray]:
+        return self.get_frame()
+
+
+class MaskedImagePipeline(BasePipeline):
     """Produce masked frames from a raw image pipeline."""
 
     def __init__(self, raw_pipe: RawImagePipeline, scale: float = DETECTION_SCALE):
+        super().__init__()
         self.raw_pipe = raw_pipe
         self.scale = scale
-        self.frame: Optional[np.ndarray] = None
-        self.lock = threading.Lock()
-        self.running = False
-        self.thread: Optional[threading.Thread] = None
 
-    def start(self) -> None:
-        if self.running:
-            return
-        self.running = True
-        self.thread = threading.Thread(target=self._run, daemon=True)
-        self.thread.start()
-
-    def _run(self) -> None:
-        while self.running:
-            frame = self.raw_pipe.get_raw_frame()
-            if frame is None:
-                time.sleep(0.01)
-                continue
-            mask = compute_color_mask(frame, scale=self.scale)
-            with self.lock:
-                self.frame = mask
-
-    def stop(self) -> None:
-        self.running = False
-        if self.thread:
-            self.thread.join()
+    def process_frame(self) -> Optional[np.ndarray]:
+        frame = self.raw_pipe.get_raw_frame()
+        if frame is None:
+            return None
+        mask = compute_color_mask(frame, scale=self.scale)
+        return mask
 
     def get_masked_frame(self) -> Optional[np.ndarray]:
-        with self.lock:
-            return None if self.frame is None else self.frame.copy()
+        return self.get_frame()
 
 
-class AnnotatedImagePipeline:
+class AnnotatedImagePipeline(BasePipeline):
     """Generate annotated frames using a provided processor function."""
 
     def __init__(
@@ -90,35 +96,16 @@ class AnnotatedImagePipeline:
         raw_pipe: RawImagePipeline,
         processor: Callable[[np.ndarray], np.ndarray],
     ):
+        super().__init__()
         self.raw_pipe = raw_pipe
         self.processor = processor
-        self.frame: Optional[np.ndarray] = None
-        self.lock = threading.Lock()
-        self.running = False
-        self.thread: Optional[threading.Thread] = None
 
-    def start(self) -> None:
-        if self.running:
-            return
-        self.running = True
-        self.thread = threading.Thread(target=self._run, daemon=True)
-        self.thread.start()
-
-    def _run(self) -> None:
-        while self.running:
-            frame = self.raw_pipe.get_raw_frame()
-            if frame is None:
-                time.sleep(0.01)
-                continue
-            annotated = self.processor(frame)
-            with self.lock:
-                self.frame = annotated
-
-    def stop(self) -> None:
-        self.running = False
-        if self.thread:
-            self.thread.join()
+    def process_frame(self) -> Optional[np.ndarray]:
+        frame = self.raw_pipe.get_raw_frame()
+        if frame is None:
+            return None
+        annotated = self.processor(frame)
+        return annotated
 
     def get_annotated_frame(self) -> Optional[np.ndarray]:
-        with self.lock:
-            return self.frame
+        return self.get_frame()


### PR DESCRIPTION
## Summary
- add `BasePipeline` with common start/stop logic
- refactor `RawImagePipeline`, `MaskedImagePipeline` and `AnnotatedImagePipeline` to inherit from it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857d2bacce08328970a2ba971c0f0b0