### PR TITLE
Add Master Pico log viewer

### DIFF
--- a/ball_example/app.py
+++ b/ball_example/app.py
@@ -212,6 +212,12 @@ def send_cmd():
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
+@app.route("/pico_lines")
+def pico_lines():
+    lines = api.read_pico_lines()
+    return jsonify({"lines": lines})
+
+
 @app.route("/send_message", methods=["POST"])
 def send_message():
     """Dispatch a control message to the running scenario."""

--- a/ball_example/master_pico.py
+++ b/ball_example/master_pico.py
@@ -1,0 +1,89 @@
+import threading
+import sys
+from typing import Optional, List
+from collections import deque
+import serial
+import serial.tools.list_ports
+import time
+
+class MasterPico:
+    """Simple manager for a master Pico handling multiple PlotClock slaves."""
+
+    def __init__(self, port: Optional[str] = None, *, baudrate: int = 115200, timeout: float = 0.2) -> None:
+        self.port = port
+        self.baudrate = baudrate
+        self.timeout = timeout
+        self._ser: Optional[serial.Serial] = None
+        self._reader_thread: Optional[threading.Thread] = None
+        self._interactive = False
+        self._lines: deque[str] = deque(maxlen=200)
+
+    # ------------------------------------------------------------------
+    def _find_port(self) -> Optional[str]:
+        for p in serial.tools.list_ports.comports():
+            if (p.vid, p.pid) in {(0x2E8A, 0x0005), (0x2E8A, 0x000A)} or "Pico" in p.description:
+                return p.device
+        return None
+
+    # ------------------------------------------------------------------
+    def connect(self) -> None:
+        if self._ser and self._ser.is_open:
+            return
+        port = self.port or self._find_port()
+        if not port:
+            raise RuntimeError("Could not auto-detect serial port; specify port explicitly.")
+        try:
+            self._ser = serial.Serial(port, baudrate=self.baudrate, timeout=self.timeout)
+            time.sleep(2)  # allow USB-CDC reset
+            self._start_reader()
+        except serial.SerialException as e:
+            raise RuntimeError(f"Failed to open serial port {port}: {e}") from e
+
+    # ------------------------------------------------------------------
+    @property
+    def connected(self) -> bool:
+        return bool(self._ser and self._ser.is_open)
+
+    # ------------------------------------------------------------------
+    def _reader(self) -> None:
+        while self._ser and self._ser.is_open:
+            try:
+                line = self._ser.readline()
+                if not line:
+                    continue
+                text = line.decode("utf-8", "replace").rstrip()
+                self._lines.append(text)
+                sys.stdout.write(f"\r\n{text}\n")
+                if self._interactive:
+                    sys.stdout.write("> ")
+                sys.stdout.flush()
+            except (serial.SerialException, OSError):
+                break
+            except UnicodeDecodeError:
+                continue
+
+    def _start_reader(self) -> None:
+        if not self._reader_thread or not self._reader_thread.is_alive():
+            self._reader_thread = threading.Thread(target=self._reader, daemon=True)
+            self._reader_thread.start()
+
+    # ------------------------------------------------------------------
+    def send_command(self, cmd: str) -> None:
+        if not self.connected:
+            raise RuntimeError("Serial port not open; call connect() first.")
+        if not cmd.endswith("\n"):
+            cmd += "\n"
+        self._ser.write(cmd.encode("utf-8"))
+        self._ser.flush()
+
+    # ------------------------------------------------------------------
+    def get_lines(self) -> List[str]:
+        lines = list(self._lines)
+        self._lines.clear()
+        return lines
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        if self._ser and self._ser.is_open:
+            self._ser.close()
+        self._ser = None

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -193,12 +193,12 @@
       'getMaxX()',
       'getMinY()',
       'getStartAngle()',
-      'startPoseCalibration(eftStartPose,rightStartPose)',
+      'startPoseCalibration()',
       'goHome()',
-      'checkTarget(Tx, Ty)',
-      'gotoXY(Tx, Ty)',
-      'setXY(Tx, Ty, n_steps=100, stepDelay=2)',
-      'setXYrel(Tx, Ty, n_steps=100, stepDelay=2)'
+      'checkTarget()',
+      'gotoXY()',
+      'setXY()',
+      'setXYrel()'
     ];
     setInterval(updateStats, 250);
     updateStats();
@@ -225,17 +225,17 @@
       cmdList.innerHTML = '';
       let opts = [];
       if(!val || val.indexOf('.') === -1){
-        opts = clockIds.map(id => `P${id}`);
+        opts = clockIds.map(id => `P${id}.`);
       } else if(/P\d+\.$/.test(val)){
-        opts = ['p','sr','sl'].map(s => val + s);
+        opts = ['p.','sr.','sl.'].map(s => val + s);
       } else {
         const m = val.match(/^(P\d+\.(?:p|sr|sl))\.?/);
         if(m){
           const prefix = m[1];
           if(prefix.endsWith('p')){
-            opts = pCmds.map(c => `${prefix}.${c}`);
+            opts = pCmds.map(c => `${prefix}.${c}.`);
           } else {
-            opts = servoCmds.map(c => `${prefix}.${c}`);
+            opts = servoCmds.map(c => `${prefix}.${c}.`);
           }
         }
       }

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -170,10 +170,13 @@
         }
       } catch(e){ console.error(e); }
     }
-    const startBtn = qs('#start-btn');
-    const tuneBtn  = qs('#tune-btn');
-    const cmdList  = qs('#cmd-list');
-    let clockIds   = [];
+    const startBtn   = qs('#start-btn');
+    const tuneBtn    = qs('#tune-btn');
+    const connectBtn = qs('#connect-btn');
+    const cmdBox     = qs('#cmd-box');
+    const cmdList    = qs('#cmd-list');
+    const picoLog    = qs('#pico-log');
+    let clockIds     = [];
     const servoCmds = [
       'getAngle()',
       'setAngle(rad)',
@@ -194,7 +197,6 @@
     ];
     setInterval(updateStats, 250);
     updateStats();
-    updateCmdList();
 
     async function pollPicoLog(){
       try{
@@ -211,6 +213,7 @@
     }
     setInterval(pollPicoLog, 500);
     pollPicoLog();
+    updateCmdList();
 
     function updateCmdList(){
       const val = cmdBox.value;
@@ -268,9 +271,6 @@
     });
 
     /* Pico connect button */
-    const connectBtn = qs('#connect-btn');
-    const cmdBox    = qs('#cmd-box');
-    const picoLog   = qs('#pico-log');
     connectBtn.addEventListener('click', async () => {
       if(connectBtn.classList.contains('connected')) return;
       connectBtn.disabled = true;

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -133,6 +133,8 @@
     function qs(sel){ return document.querySelector(sel); }
 
     /* live stats */
+    let idsInitialized = false;
+
     async function updateStats(){
       try{
         const r = await fetch('/debug_data');
@@ -141,12 +143,15 @@
         qs('#num_balls').textContent = d.num_balls;
         qs('#speeds').textContent    = '[' + d.speeds.join(', ') + ']';
         qs('#ball_ids').textContent  = d.ball_ids.join(', ');
-        if(Array.isArray(d.markers)){
+        if(!idsInitialized && Array.isArray(d.markers)){
           const ids = d.markers
             .filter(m => m.type === 'ArucoHitter' || m.type === 'ArucoManager')
             .map(m => m.id);
-          clockIds = Array.from(new Set(ids));
-          updateCmdList();
+          if(ids.length){
+            clockIds = Array.from(new Set(ids));
+            idsInitialized = true;
+            updateCmdList();
+          }
         }
         const scSpan = qs('#scenario_status');
         if(d.scenario_loaded){

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -113,7 +113,8 @@
   <!-- Connect Pico button -->
   <button id="connect-btn">Connect Pico</button>
   <!-- Command input -->
-  <input id="cmd-box" type="text" placeholder="command + Enter">
+  <input id="cmd-box" type="text" placeholder="command + Enter" list="cmd-list" autocomplete="off">
+  <datalist id="cmd-list"></datalist>
   <pre id="pico-log"></pre>
 
   <div id="status">
@@ -140,6 +141,13 @@
         qs('#num_balls').textContent = d.num_balls;
         qs('#speeds').textContent    = '[' + d.speeds.join(', ') + ']';
         qs('#ball_ids').textContent  = d.ball_ids.join(', ');
+        if(Array.isArray(d.markers)){
+          const ids = d.markers
+            .filter(m => m.type === 'ArucoHitter' || m.type === 'ArucoManager')
+            .map(m => m.id);
+          clockIds = Array.from(new Set(ids));
+          updateCmdList();
+        }
         const scSpan = qs('#scenario_status');
         if(d.scenario_loaded){
           scSpan.textContent = d.scenario_name + (d.scenario_running ? ' (running)' : ' (ready)');
@@ -164,8 +172,29 @@
     }
     const startBtn = qs('#start-btn');
     const tuneBtn  = qs('#tune-btn');
+    const cmdList  = qs('#cmd-list');
+    let clockIds   = [];
+    const servoCmds = [
+      'getAngle()',
+      'setAngle(rad)',
+      'calibrateRotation(rad)'
+    ];
+    const pCmds = [
+      'setup(L1,L2,L3,L4,hitDia,servoMarginAngle=2.5/180*math.pi)',
+      'getXY()',
+      'getMaxX()',
+      'getMinY()',
+      'getStartAngle()',
+      'startPoseCalibration(eftStartPose,rightStartPose)',
+      'goHome()',
+      'checkTarget(Tx, Ty)',
+      'gotoXY(Tx, Ty)',
+      'setXY(Tx, Ty, n_steps=100, stepDelay=2)',
+      'setXYrel(Tx, Ty, n_steps=100, stepDelay=2)'
+    ];
     setInterval(updateStats, 250);
     updateStats();
+    updateCmdList();
 
     async function pollPicoLog(){
       try{
@@ -182,10 +211,38 @@
     }
     setInterval(pollPicoLog, 500);
     pollPicoLog();
+
+    function updateCmdList(){
+      const val = cmdBox.value;
+      cmdList.innerHTML = '';
+      let opts = [];
+      if(!val || val.indexOf('.') === -1){
+        opts = clockIds.map(id => `P${id}`);
+      } else if(/P\d+\.$/.test(val)){
+        opts = ['p','sr','sl'].map(s => val + s);
+      } else {
+        const m = val.match(/^(P\d+\.(?:p|sr|sl))\.?/);
+        if(m){
+          const prefix = m[1];
+          if(prefix.endsWith('p')){
+            opts = pCmds.map(c => `${prefix}.${c}`);
+          } else {
+            opts = servoCmds.map(c => `${prefix}.${c}`);
+          }
+        }
+      }
+      for(const o of opts){
+        const option = document.createElement('option');
+        option.value = o;
+        cmdList.appendChild(option);
+      }
+    }
     /* open tuning page */
     tuneBtn.addEventListener('click', () => {
       window.open('/tune', '_blank');
     });
+    cmdBox.addEventListener('input', updateCmdList);
+    cmdBox.addEventListener('paste', () => setTimeout(updateCmdList, 0));
     
     /* Scenario start button */
     startBtn.addEventListener('click', async () => {
@@ -226,6 +283,7 @@
           connectBtn.textContent = 'Pico Connected';
           cmdBox.classList.add('enabled');
           cmdBox.focus();
+          updateCmdList();
         } else {
           alert('Connect failed: ' + d.message);
           connectBtn.textContent = 'Connect Pico';

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -89,6 +89,20 @@
       background:#fff;
       color:#000;
     }
+    #pico-log{
+      position:absolute;
+      top:86px;
+      right:10px;
+      width:180px;
+      height:120px;
+      overflow:auto;
+      padding:6px 8px;
+      border-radius:5px;
+      background:rgba(255,255,255,0.8);
+      color:#000;
+      font-size:12px;
+      white-space:pre-wrap;
+    }
   </style>
 </head>
 <body>
@@ -100,6 +114,7 @@
   <button id="connect-btn">Connect Pico</button>
   <!-- Command input -->
   <input id="cmd-box" type="text" placeholder="command + Enter">
+  <pre id="pico-log"></pre>
 
   <div id="status">
     <div>Number of Balls: <span id="num_balls">0</span></div>
@@ -151,6 +166,22 @@
     const tuneBtn  = qs('#tune-btn');
     setInterval(updateStats, 250);
     updateStats();
+
+    async function pollPicoLog(){
+      try{
+        const r = await fetch('/pico_lines');
+        if(!r.ok) return;
+        const d = await r.json();
+        for(const line of d.lines){
+          picoLog.textContent += line + '\n';
+        }
+        if(d.lines && d.lines.length){
+          picoLog.scrollTop = picoLog.scrollHeight;
+        }
+      }catch(e){ console.error(e); }
+    }
+    setInterval(pollPicoLog, 500);
+    pollPicoLog();
     /* open tuning page */
     tuneBtn.addEventListener('click', () => {
       window.open('/tune', '_blank');
@@ -182,6 +213,7 @@
     /* Pico connect button */
     const connectBtn = qs('#connect-btn');
     const cmdBox    = qs('#cmd-box');
+    const picoLog   = qs('#pico-log');
     connectBtn.addEventListener('click', async () => {
       if(connectBtn.classList.contains('connected')) return;
       connectBtn.disabled = true;

--- a/examples/high_level_demo.py
+++ b/examples/high_level_demo.py
@@ -22,6 +22,7 @@ def main() -> None:
     api = GameAPI()
     api.set_cam_source(0)
     api.start()
+    api.connect_pico()
 
     print("Waiting for detections...")
     clocks = []
@@ -43,20 +44,20 @@ def main() -> None:
     attacker = None
     defender = None
 
-    # if clocks:
-    #     def _get_dets():
-    #         with api.lock:
-    #             return api.balls + api.arucos
-    #
-    #     print("Calibrating clocks…")
-    #     calibrate_clocks(clocks, _get_dets)
-    #
-    #     attacker = clocks[0].attack(api.frame_size, (100.0, 0.0))
-    #     defender = clocks[1].defend(api.frame_size) if len(clocks) > 1 else None
-    #
-    #     attacker.on_start()
-    #     if defender:
-    #         defender.on_start()
+    if clocks:
+        def _get_dets():
+            with api.lock:
+                return api.balls + api.arucos
+
+        print("Calibrating clocks…")
+        calibrate_clocks(clocks, _get_dets)
+
+        attacker = clocks[0].attack(api.frame_size, (100.0, 0.0))
+        defender = clocks[1].defend(api.frame_size) if len(clocks) > 1 else None
+
+        attacker.on_start()
+        if defender:
+            defender.on_start()
 
     root = tk.Tk()
     root.title("High Level Demo")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -91,6 +91,14 @@ def test_debug_endpoint():
     assert "gadgets" in data
 
 
+def test_pico_lines_endpoint():
+    client = hockey_app.app.test_client()
+    r = client.get("/pico_lines")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "lines" in data
+
+
 def test_game_api_set_cam_source():
     from ball_example.game_api import GameAPI
     api = GameAPI()


### PR DESCRIPTION
## Summary
- store lines read from MasterPico
- allow ArucoManager markers to spawn PlotClock devices
- expose `/pico_lines` endpoint and display master Pico output on the homepage
- test new endpoint
- drop unused serial parameters from `PlotClock`

## Testing
- `pytest -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685d4c2371488328ad48feeb72809d58