### PR TITLE
Fix PlotClock calibration command

### DIFF
--- a/ball_example/gadgets.py
+++ b/ball_example/gadgets.py
@@ -192,7 +192,10 @@ class PlotClock(Gadgets):
         # FSM --------------------------------------------------
         if self._cal_state == 0:
             x,y = self._mm_pts[0]
-            self.send_command(f"P1.p.setXY({x}, {y})")
+            # send a move command to the associated PlotClock. Prefix
+            # ``P{device_id}.`` is added automatically by ``send_command`` so
+            # we only issue the raw command here.
+            self.send_command(f"p.setXY({x}, {y})")
             self._last_cmd_t = now
             self._cal_state = 1
             return None
@@ -200,7 +203,7 @@ class PlotClock(Gadgets):
         if self._cal_state == 1 and now-self._last_cmd_t >= self._delay and marker:
             self._px_hits.append(marker.center)
             x,y = self._mm_pts[1]
-            self.send_command(f"P1.p.setXY({x}, {y})")
+            self.send_command(f"p.setXY({x}, {y})")
             self._last_cmd_t = now
             self._cal_state = 2
             return None
@@ -208,7 +211,7 @@ class PlotClock(Gadgets):
         if self._cal_state == 2 and now-self._last_cmd_t >= self._delay and marker:
             self._px_hits.append(marker.center)
             x,y = self._mm_pts[2]
-            self.send_command(f"P1.p.setXY({x}, {y})")
+            self.send_command(f"p.setXY({x}, {y})")
             self._last_cmd_t = now
             self._cal_state = 3
             return None

--- a/ball_example/game_api.py
+++ b/ball_example/game_api.py
@@ -22,7 +22,7 @@ from .detectors import ArucoDetector, BallDetector
 from .pipelines import RawImagePipeline, MaskedImagePipeline, AnnotatedImagePipeline
 from .renderers import render_overlay, draw_line
 from .models import Ball, ArucoMarker, ArucoHitter, ArucoManager
-from .gadgets import PlotClock
+from .gadgets import PlotClock, ArenaManager
 from .master_pico import MasterPico
 from .scenarios import *
 from .simple_api import CommandScenario, sort_plotclocks
@@ -107,8 +107,11 @@ class GameAPI:
 
         if self.pico_connected:
             for m in markers:
-                if isinstance(m, (ArucoHitter, ArucoManager)) and m.id not in self.plotclocks:
-                    self.plotclocks[m.id] = PlotClock(device_id=m.id, master=self.master_pico)
+                if m.id not in self.plotclocks:
+                    if isinstance(m, ArucoManager):
+                        self.plotclocks[m.id] = ArenaManager(device_id=m.id, master=self.master_pico)
+                    elif isinstance(m, ArucoHitter):
+                        self.plotclocks[m.id] = PlotClock(device_id=m.id, master=self.master_pico)
 
         scenario_line = None
         extra_pts = None

--- a/ball_example/high_level.py
+++ b/ball_example/high_level.py
@@ -69,8 +69,17 @@ def calibrate_clocks(
     while time.time() - start < timeout:
         detections = list(get_detections())
         for c in clocks:
-            if not c.calibration:
-                c.calibrate(detections)
+            if c.calibration:
+                continue
+            if c.device_id is not None:
+                sub_dets = [
+                    d
+                    for d in detections
+                    if not hasattr(d, "id") or d.id == c.device_id
+                ]
+            else:
+                sub_dets = detections
+            c.calibrate(sub_dets)
         if all(c.calibration for c in clocks):
             break
         time.sleep(0.05)


### PR DESCRIPTION
## Summary
- avoid double `P{device_id}` prefixing during calibration
- recognize `ArucoManager` markers in `GameAPI`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d8af83ce88328a7bb9453d2891865