### PR TITLE
Add link length getters

### DIFF
--- a/PlotClock/PlotClockSlave.py
+++ b/PlotClock/PlotClockSlave.py
@@ -89,6 +89,18 @@ class PlotClock:
 
     def getStartAngle(self):
         return self.startAngle
+
+    def getL1(self):
+        return self.L1
+
+    def getL2(self):
+        return self.L2
+
+    def getL3(self):
+        return self.L3
+
+    def getL4(self):
+        return self.L4
     
     def startPoseCalibration(self,leftStartPose,rightStartPose):
         self.servoLeft.startPose = leftStartPose

--- a/ball_example/gadgets.py
+++ b/ball_example/gadgets.py
@@ -237,7 +237,8 @@ class PlotClock(Gadgets):
             lines = self.master.get_lines()
             for line in lines:
                 if line.startswith(f"P{self.device_id}:"):
-                    return line.split(":", 1)[1]
+                    payload = line.split(":", 1)[1]
+                    return payload.rsplit(":", 1)[-1].strip()
             time.sleep(0.05)
 
         raise RuntimeError(f"Timed out waiting for response to {code}")


### PR DESCRIPTION
## Summary
- add new `getL1`, `getL2`, `getL3`, and `getL4` helpers to the firmware so the host can query link lengths
- ensure `_query_value` strips any prefix before returning values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ecc4e156c83288f3e1b8e6c9d37e4