### PR TITLE
Fix workspace drawing

### DIFF
--- a/ball_example/gadgets.py
+++ b/ball_example/gadgets.py
@@ -349,7 +349,14 @@ class PlotClock(Gadgets):
         color: Tuple[int, int, int] = (0, 255, 0),
         thickness: int = 2,
     ) -> None:
-        """Draw the reachable working space of this clock on ``frame``."""
+        """Draw the reachable workspace of this PlotClock on ``frame``.
+
+        The region is bounded by two vertical lines at ``x = ±max_x`` and a
+        horizontal line at ``y = min_y``.  The upper boundary is the union of two
+        circular arcs with radius ``L1 + L2``.  From ``x = -max_x`` to ``0`` the
+        arc is centred at ``(L3 / 2, 0)`` while from ``0`` to ``max_x`` it is
+        centred at ``(-L3 / 2, 0)``.
+        """
         import cv2
 
         if not self.calibration:
@@ -362,9 +369,9 @@ class PlotClock(Gadgets):
 
         num = 50
         xs_left = np.linspace(-max_x, 0, num)
-        ys_left = np.sqrt(np.clip(r * r - (xs_left + d) ** 2, 0, None))
+        ys_left = np.sqrt(np.clip(r * r - (xs_left - d) ** 2, 0, None))
         xs_right = np.linspace(0, max_x, num)
-        ys_right = np.sqrt(np.clip(r * r - (xs_right - d) ** 2, 0, None))
+        ys_right = np.sqrt(np.clip(r * r - (xs_right + d) ** 2, 0, None))
 
         pts_mm: List[Tuple[float, float]] = list(zip(xs_left, ys_left))
         pts_mm += list(zip(xs_right, ys_right))


### PR DESCRIPTION
## Summary
- adjust `draw_working_area` docstring for clarity
- correct workspace arcs to show the intersection of disk segments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd00ec2fc8328b49bc715cf6ca7d5