### PR TITLE
Add ObstacleFollower scenario

### DIFF
--- a/ball_example/app.py
+++ b/ball_example/app.py
@@ -267,7 +267,7 @@ def toggle_mode():
     device_id = int(data.get("device_id", -1))
     mode = data.get("mode")
     clock = api.plotclocks.get(device_id)
-    if clock is None or mode not in {"attack", "defend", "hit_standing"}:
+    if clock is None or mode not in {"attack", "defend", "hit_standing", "follow_obstacle"}:
         return jsonify({"status": "error", "message": "invalid"}), 400
 
     if api.clock_modes.get(device_id) == mode:

--- a/ball_example/gadgets.py
+++ b/ball_example/gadgets.py
@@ -384,6 +384,11 @@ class PlotClock(Gadgets):
         from .scenarios import StandingBallHitter
         return StandingBallHitter(self)
 
+    def follow_obstacle(self):
+        """Return an ObstacleFollower scenario for this clock."""
+        from .scenarios import ObstacleFollower
+        return ObstacleFollower(self)
+
     def draw_working_area(
         self,
         frame: np.ndarray,

--- a/ball_example/game_api.py
+++ b/ball_example/game_api.py
@@ -217,6 +217,8 @@ class GameAPI:
             sc = clock.defend(self.frame_size)
         elif mode == "hit_standing":
             sc = clock.hit_standing_ball()
+        elif mode == "follow_obstacle":
+            sc = clock.follow_obstacle()
         else:
             raise ValueError("bad mode")
         sc.on_start()

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -261,6 +261,9 @@
           ['defend','Defend'],
           ['hit_standing','Hit']
         ];
+        if(g.class === 'ArenaManager'){
+          modes.push(['follow_obstacle','FolOb']);
+        }
         for(const [mode,label] of modes){
           const b = document.createElement('button');
           b.textContent = label;


### PR DESCRIPTION
## Summary
- expose ObstacleFollower as a PlotClock mode
- add `follow_obstacle` helper on PlotClock
- enable new mode in Flask API and UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686109cc7b5c8326a399fdd43bbd0fe5