### PR TITLE
Add obstacle support to grab-and-release

### DIFF
--- a/ball_example/gadgets.py
+++ b/ball_example/gadgets.py
@@ -6,7 +6,7 @@ import serial.tools.list_ports
 import time
 import math
 import numpy as np
-from .models import Ball, ArucoMarker, ArucoHitter, ArucoManager, Arena
+from .models import Ball, Obstacle, ArucoMarker, ArucoHitter, ArucoManager, Arena
 
 
 class Gadgets:
@@ -456,3 +456,10 @@ class ArenaManager(PlotClock):
                         return  # outside arena, ignore command
 
         super().send_command(cmd_name, *params)
+
+    # ------------------------------------------------------------------
+    def grab_and_release(self, obj: Union[Ball, Obstacle], target_x: float, target_y: float):
+        """Return a GrabAndRelease scenario for this arena manager."""
+        from .scenarios import GrabAndRelease
+
+        return GrabAndRelease(self, obj, (target_x, target_y))

--- a/tests/test_grab_release.py
+++ b/tests/test_grab_release.py
@@ -1,0 +1,77 @@
+import os, sys, pytest
+
+pytest.importorskip("numpy")
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from ball_example.gadgets import ArenaManager
+from ball_example.models import Ball, Obstacle
+
+
+def test_grab_and_release_commands():
+    mgr = ArenaManager(device_id=1)
+    mgr.calibration = {
+        "u_x": np.array([1.0, 0.0]),
+        "u_y": np.array([0.0, 1.0]),
+        "origin_px": (0, 0),
+    }
+
+    class DummyMaster:
+        def __init__(self):
+            self.sent = []
+
+        def send_command(self, cmd: str) -> None:
+            self.sent.append(cmd)
+
+    master = DummyMaster()
+    mgr.master = master
+
+    ball = Ball((10, 20), 5)
+    scenario = mgr.grab_and_release(ball, 100, 200)
+    scenario.on_start()
+
+    scenario.update([])
+    assert master.sent == ["P1.p.setXY(10, 20)"]
+
+    scenario._last_time -= scenario.WAIT_TIME + 0.1
+    scenario.update([])
+    assert master.sent == ["P1.p.setXY(10, 20)", "P1.p.setXY(100, 200)"]
+
+    scenario._last_time -= scenario.WAIT_TIME + 0.1
+    scenario.update([])
+    assert scenario.finished
+
+
+def test_grab_and_release_obstacle():
+    mgr = ArenaManager(device_id=1)
+    mgr.calibration = {
+        "u_x": np.array([1.0, 0.0]),
+        "u_y": np.array([0.0, 1.0]),
+        "origin_px": (0, 0),
+    }
+
+    class DummyMaster:
+        def __init__(self):
+            self.sent = []
+
+        def send_command(self, cmd: str) -> None:
+            self.sent.append(cmd)
+
+    master = DummyMaster()
+    mgr.master = master
+
+    obs = Obstacle(0, [], (30, 40))
+    scenario = mgr.grab_and_release(obs, 100, 200)
+    scenario.on_start()
+
+    scenario.update([])
+    assert master.sent == ["P1.p.setXY(30, 40)"]
+
+    scenario._last_time -= scenario.WAIT_TIME + 0.1
+    scenario.update([])
+    assert master.sent == ["P1.p.setXY(30, 40)", "P1.p.setXY(100, 200)"]
+
+    scenario._last_time -= scenario.WAIT_TIME + 0.1
+    scenario.update([])
+    assert scenario.finished


### PR DESCRIPTION
## Summary
- import `Obstacle` in gadgets and scenarios
- update `grab_and_release` signature to accept `Obstacle`
- update test for `GrabAndRelease` scenario and add case for obstacle

## Testing
- `pytest -q` *(fails: 4 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685fe4760b648328bb6a2184d5f1933a