### PR TITLE
Add coordinate-based move preview

### DIFF
--- a/ball_example/detectors.py
+++ b/ball_example/detectors.py
@@ -41,13 +41,14 @@ class ArucoDetector:
 
                 cx = int(np.mean(pts[:, 0]))
                 cy = int(np.mean(pts[:, 1]))
-                if int(marker_id) in (0, 1):
+                m_id = int(marker_id)
+                if m_id in (0, 1):
                     markers.append(
-                        Obstacle(id=int(marker_id), corners=pts_int, center=(cx, cy))
+                        Obstacle(id=m_id, corners=pts_int, center=(cx, cy))
                     )
                 else:
                     markers.append(
-                        ArucoMarker(id=int(marker_id), corners=pts_int, center=(cx, cy))
+                        ArucoMarker(id=m_id, corners=pts_int, center=(cx, cy))
                     )
 
         if ids4 is not None:

--- a/ball_example/gadgets.py
+++ b/ball_example/gadgets.py
@@ -16,7 +16,7 @@ from .models import Ball, Obstacle, ArucoMarker, ArucoHitter, ArucoManager, Aren
 # ``CAL_MARGIN_SCALE`` expresses this margin relative to the mechanism's
 # first link length ``L1``.  The default value preserves the previous
 # behaviour of a 10 mm margin when ``L1`` is 35 mm.
-CAL_MARGIN_SCALE = 7.0 / 35.0
+CAL_MARGIN_SCALE = 5.0 / 35.0
 
 
 class Gadgets:
@@ -208,7 +208,7 @@ class PlotClock(Gadgets):
         span_x = 2 * self.max_x
         span_y = self.y_range[1] - self.min_y
         self._axis_len = 0.5 * min(span_x, span_y)
-        base_x = 0
+        base_x = self._axis_len/2
         base_y = self.min_y
 
         self.cal_margin_mm = self.cal_margin_scale * self.l1
@@ -219,7 +219,7 @@ class PlotClock(Gadgets):
         self._mm_pts = [
             (base_x + m, base_y + self._axis_len - m),
             (base_x + m, base_y + m),
-            (-base_x, base_y + m),]
+            (base_x - m, base_y + m),]
 
         self._px_hits: List[Tuple[int,int]] = []
         self._last_cmd_t: float = 0.0

--- a/ball_example/gadgets.py
+++ b/ball_example/gadgets.py
@@ -518,8 +518,11 @@ class ArenaManager(PlotClock):
         super().send_command(cmd_name, *params)
 
     # ------------------------------------------------------------------
-    def grab_and_release(self, obj: Union[Ball, Obstacle], target_x: float, target_y: float):
-        """Return a GrabAndRelease scenario for this arena manager."""
-        from .scenarios import GrabAndRelease
+    def move_object(self, obj: Union[Ball, Obstacle], target_x: float, target_y: float):
+        """Return a MoveObject scenario for this arena manager."""
+        from .scenarios import MoveObject
 
-        return GrabAndRelease(self, obj, (target_x, target_y))
+        return MoveObject(self, obj, (target_x, target_y))
+
+    # backwards compatibility
+    grab_and_release = move_object

--- a/ball_example/game_api.py
+++ b/ball_example/game_api.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import threading
 import time
 import math
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union, Tuple
 
 import cv2
 import numpy as np
@@ -53,6 +53,7 @@ class GameAPI:
         self.scenario_enabled = False
         self.clock_scenarios: Dict[int, Scenario] = {}
         self.clock_modes: Dict[int, str] = {}
+        self.preview_targets: Dict[int, Tuple[float, float]] = {}
         self._cam_started = False
 
     # ------------------------------------------------------------------
@@ -143,6 +144,14 @@ class GameAPI:
             if labels:
                 extra_labels.extend(labels if isinstance(labels, list) else [labels])
 
+        with self.lock:
+            preview = list(self.preview_targets.items())
+        for dev_id, tgt in preview:
+            clock = self.plotclocks.get(dev_id)
+            if isinstance(clock, ArenaManager) and clock.calibration:
+                extra_pts.append(clock.mm_to_pixel(tgt))
+                extra_labels.append("Target")
+
         annotated = render_overlay(
             frame,
             balls,
@@ -217,6 +226,8 @@ class GameAPI:
             sc = clock.defend(self.frame_size)
         elif mode == "hit_standing":
             sc = clock.hit_standing_ball()
+        elif mode == "move_object":
+            raise ValueError("move_object requires parameters")
         else:
             raise ValueError("bad mode")
         sc.on_start()
@@ -228,6 +239,25 @@ class GameAPI:
         if sc:
             sc.on_stop()
         self.clock_modes.pop(device_id, None)
+
+    def start_move_object(
+        self,
+        manager: ArenaManager,
+        obj: Union[Ball, Obstacle],
+        target_mm: Tuple[float, float],
+    ) -> None:
+        sc = manager.move_object(obj, target_mm[0], target_mm[1])
+        sc.on_start()
+        self.clock_scenarios[manager.device_id] = sc
+        self.clock_modes[manager.device_id] = "move_object"
+
+    def set_preview_target(self, device_id: int, target_mm: Tuple[float, float]) -> None:
+        with self.lock:
+            self.preview_targets[device_id] = target_mm
+
+    def clear_preview_target(self, device_id: int) -> None:
+        with self.lock:
+            self.preview_targets.pop(device_id, None)
 
     def process_message(self, message: Dict[str, Any]) -> None:
         if self._current_scenario:

--- a/ball_example/scenarios.py
+++ b/ball_example/scenarios.py
@@ -534,7 +534,7 @@ class StandingBallHitter(Scenario):
         return ["Start"]
 
 
-class GrabAndRelease(Scenario):
+class MoveObject(Scenario):
     """Move to an object, grab it, then move to a target and release."""
 
     WAIT_TIME = 0.5  # seconds to wait after each move

--- a/ball_example/scenarios.py
+++ b/ball_example/scenarios.py
@@ -539,7 +539,7 @@ class MoveObject(Scenario):
 
     #: seconds to wait between actions. This gives the PlotClock enough time to
     #: physically move and actuate its gripper.
-    WAIT_TIME = 0.5
+    WAIT_TIME = 4
 
     def __init__(self, manager: "ArenaManager", obj: Union[Ball, Obstacle], target_mm: Tuple[float, float]):
         self.manager = manager

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -152,6 +152,7 @@
 
     /* live stats */
     let idsInitialized = false;
+    let lastClockKey = '';
 
     async function updateStats(){
       try{
@@ -177,7 +178,7 @@
         } else {
           scSpan.textContent = 'None';
         }
-        renderClocks(d);
+        maybeRenderClocks(d);
 
         if(!d.scenario_loaded){
           startBtn.disabled = true;
@@ -244,6 +245,18 @@
     setInterval(pollPicoLog, 500);
     pollPicoLog();
     updateCmdList();
+
+    function maybeRenderClocks(info){
+      const active = info.active_modes || {};
+      const key = JSON.stringify({
+        g:(info.gadgets||[]).map(g=>[g.id,g.class,active[g.id]]),
+        b:(info.ball_details||[]).map(b=>b.id),
+        o:(info.markers||[]).filter(m=>m.type==='Obstacle').map(m=>m.id)
+      });
+      if(key === lastClockKey) return;
+      lastClockKey = key;
+      renderClocks(info);
+    }
 
     function renderClocks(info){
       clockList.innerHTML = '';

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -204,6 +204,7 @@
     const calibBtn   = qs('#calibrate-all');
     const clockList  = qs('#clock-list');
     let clockIds     = [];
+    const moveInputs = {}; // persist move-object selections and coordinates
     const servoCmds = [
       'getAngle()',
       'setAngle(rad)',
@@ -262,7 +263,8 @@
       clockList.innerHTML = '';
       if(!Array.isArray(info.gadgets)) return;
       const active = info.active_modes || {};
-      for(const g of info.gadgets){
+        for(const g of info.gadgets){
+        const rec = moveInputs[g.id] || {};
         if(g.class !== 'PlotClock' && g.class !== 'ArenaManager') continue;
         const div = document.createElement('div');
         div.className = 'clock-entry';
@@ -312,8 +314,12 @@
                 objSel.appendChild(o);
               }
             }
-            xInput.addEventListener('input', ()=>previewTarget(g.id, xInput.value, yInput.value));
-            yInput.addEventListener('input', ()=>previewTarget(g.id, xInput.value, yInput.value));
+            objSel.value = rec.obj || objSel.value;
+            xInput.value = rec.x || '';
+            yInput.value = rec.y || '';
+            objSel.addEventListener('change', ()=>{ rec.obj = objSel.value; moveInputs[g.id] = rec; });
+            xInput.addEventListener('input', ()=>{ rec.x = xInput.value; moveInputs[g.id]=rec; previewTarget(g.id, xInput.value, yInput.value); });
+            yInput.addEventListener('input', ()=>{ rec.y = yInput.value; moveInputs[g.id]=rec; previewTarget(g.id, xInput.value, yInput.value); });
             b.addEventListener('click', ()=>moveObject(g.id, objSel.value, xInput.value, yInput.value));
             div.appendChild(b);
             div.appendChild(objSel);

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -256,11 +256,13 @@
         const span = document.createElement('span');
         span.textContent = 'P' + g.id;
         div.appendChild(span);
-        const modes = [
-          ['attack','Attack'],
-          ['defend','Defend'],
-          ['hit_standing','Hit']
-        ];
+        const modes = g.class === 'ArenaManager'
+          ? [['move_object','Move Object']]
+          : [
+              ['attack','Attack'],
+              ['defend','Defend'],
+              ['hit_standing','Hit']
+            ];
         for(const [mode,label] of modes){
           const b = document.createElement('button');
           b.textContent = label;
@@ -273,8 +275,41 @@
               b.disabled = true;
             }
           }
-          b.addEventListener('click', ()=>toggleMode(g.id, mode));
-          div.appendChild(b);
+          if(g.class === 'ArenaManager'){
+            const objSel = document.createElement('select');
+            const xInput = document.createElement('input');
+            xInput.type = 'number';
+            xInput.placeholder = 'x';
+            xInput.style.width = '50px';
+            const yInput = document.createElement('input');
+            yInput.type = 'number';
+            yInput.placeholder = 'y';
+            yInput.style.width = '50px';
+            for(const ball of info.ball_details||[]){
+              const o = document.createElement('option');
+              o.value = 'ball:' + ball.id;
+              o.textContent = 'Ball ' + ball.id.slice(0,4);
+              objSel.appendChild(o);
+            }
+            for(const m of (info.markers||[])){
+              if(m.type === 'Obstacle'){
+                const o = document.createElement('option');
+                o.value = 'obs:' + m.id;
+                o.textContent = 'Obs ' + m.id;
+                objSel.appendChild(o);
+              }
+            }
+            xInput.addEventListener('input', ()=>previewTarget(g.id, xInput.value, yInput.value));
+            yInput.addEventListener('input', ()=>previewTarget(g.id, xInput.value, yInput.value));
+            b.addEventListener('click', ()=>moveObject(g.id, objSel.value, xInput.value, yInput.value));
+            div.appendChild(b);
+            div.appendChild(objSel);
+            div.appendChild(xInput);
+            div.appendChild(yInput);
+          } else {
+            b.addEventListener('click', ()=>toggleMode(g.id, mode));
+            div.appendChild(b);
+          }
         }
         clockList.appendChild(div);
       }
@@ -383,6 +418,30 @@
           alert('Mode error: ' + (d.message||''));
         }
       }catch(e){ alert('Error: ' + e); }
+    }
+
+    async function moveObject(id, obj, x, y){
+      try{
+        const r = await fetch('/move_object', {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({device_id:id, object:obj, x:parseFloat(x), y:parseFloat(y)})
+        });
+        const d = await r.json();
+        if(d.status !== 'started'){
+          alert('Move error: ' + (d.message||''));
+        }
+      }catch(e){ alert('Error: ' + e); }
+    }
+
+    async function previewTarget(id, x, y){
+      try{
+        await fetch('/preview_target', {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({device_id:id, x:parseFloat(x), y:parseFloat(y)})
+        });
+      }catch(e){ console.error(e); }
     }
 
     /* Command box enter */

--- a/tests/test_grab_release.py
+++ b/tests/test_grab_release.py
@@ -31,13 +31,21 @@ def test_move_object_ball():
     scenario = mgr.move_object(ball, 100, 200)
     scenario.on_start()
 
+    # step 0 -> move to ball
     scenario.update([])
     assert master.sent == ["P1.p.setXY(10, 20)"]
 
+    # step 1 -> grab (no command)
+    scenario._last_time -= scenario.WAIT_TIME + 0.1
+    scenario.update([])
+    assert master.sent == ["P1.p.setXY(10, 20)"]
+
+    # step 2 -> move to target
     scenario._last_time -= scenario.WAIT_TIME + 0.1
     scenario.update([])
     assert master.sent == ["P1.p.setXY(10, 20)", "P1.p.setXY(100, 200)"]
 
+    # step 3 -> release
     scenario._last_time -= scenario.WAIT_TIME + 0.1
     scenario.update([])
     assert scenario.finished
@@ -65,13 +73,21 @@ def test_move_object_obstacle():
     scenario = mgr.move_object(obs, 100, 200)
     scenario.on_start()
 
+    # step 0 -> move to object
     scenario.update([])
     assert master.sent == ["P1.p.setXY(30, 40)"]
 
+    # step 1 -> grab (no command)
+    scenario._last_time -= scenario.WAIT_TIME + 0.1
+    scenario.update([])
+    assert master.sent == ["P1.p.setXY(30, 40)"]
+
+    # step 2 -> move to target
     scenario._last_time -= scenario.WAIT_TIME + 0.1
     scenario.update([])
     assert master.sent == ["P1.p.setXY(30, 40)", "P1.p.setXY(100, 200)"]
 
+    # step 3 -> release
     scenario._last_time -= scenario.WAIT_TIME + 0.1
     scenario.update([])
     assert scenario.finished

--- a/tests/test_grab_release.py
+++ b/tests/test_grab_release.py
@@ -9,7 +9,7 @@ from ball_example.gadgets import ArenaManager
 from ball_example.models import Ball, Obstacle
 
 
-def test_grab_and_release_commands():
+def test_move_object_ball():
     mgr = ArenaManager(device_id=1)
     mgr.calibration = {
         "u_x": np.array([1.0, 0.0]),
@@ -28,7 +28,7 @@ def test_grab_and_release_commands():
     mgr.master = master
 
     ball = Ball((10, 20), 5)
-    scenario = mgr.grab_and_release(ball, 100, 200)
+    scenario = mgr.move_object(ball, 100, 200)
     scenario.on_start()
 
     scenario.update([])
@@ -43,7 +43,7 @@ def test_grab_and_release_commands():
     assert scenario.finished
 
 
-def test_grab_and_release_obstacle():
+def test_move_object_obstacle():
     mgr = ArenaManager(device_id=1)
     mgr.calibration = {
         "u_x": np.array([1.0, 0.0]),
@@ -62,7 +62,7 @@ def test_grab_and_release_obstacle():
     mgr.master = master
 
     obs = Obstacle(0, [], (30, 40))
-    scenario = mgr.grab_and_release(obs, 100, 200)
+    scenario = mgr.move_object(obs, 100, 200)
     scenario.on_start()
 
     scenario.update([])


### PR DESCRIPTION
## Summary
- remove `ArucoTarget` marker type and detection
- accept target coordinates for move-object command
- add `/preview_target` route and preview overlay
- update front-end with coordinate inputs

## Testing
- `pytest -q` *(fails: 4 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68613467b85083289edf2aa60053a8aa