### PR TITLE
Keep move-object target visible

### DIFF
--- a/ball_example/app.py
+++ b/ball_example/app.py
@@ -10,7 +10,7 @@ if __package__ in (None, ""):
 
 from .game_api import GameAPI
 from .detectors import BallDetector
-from .models import ArucoWall, Arena
+from .models import ArucoWall, Arena, Obstacle
 from .gadgets import ArenaManager
 from high_level import calibrate_clocks, draw_arena
 
@@ -280,6 +280,63 @@ def toggle_mode():
 
     api.start_clock_mode(clock, mode)
     return jsonify({"status": "started"})
+
+
+@app.route("/move_object", methods=["POST"])
+def move_object_route():
+    data = request.get_json(silent=True) or {}
+    device_id = int(data.get("device_id", -1))
+    obj_spec = data.get("object")
+    try:
+        x_mm = float(data.get("x"))
+        y_mm = float(data.get("y"))
+    except (TypeError, ValueError):
+        return jsonify({"status": "error", "message": "invalid"}), 400
+    with api.lock:
+        manager = api.plotclocks.get(device_id)
+        if not isinstance(manager, ArenaManager):
+            return jsonify({"status": "error", "message": "invalid"}), 400
+        if not obj_spec:
+            return jsonify({"status": "error", "message": "invalid"}), 400
+
+        if obj_spec.startswith("ball:"):
+            bid = obj_spec.split(":", 1)[1]
+            obj = next((b for b in api.balls if b.id == bid), None)
+        elif obj_spec.startswith("obs:"):
+            oid = int(obj_spec.split(":", 1)[1])
+            obj = next((m for m in api.arucos if isinstance(m, Obstacle) and m.id == oid), None)
+        else:
+            obj = None
+
+    if obj is None:
+        return jsonify({"status": "error", "message": "not found"}), 400
+
+    if device_id in api.clock_scenarios:
+        api.stop_clock_mode(device_id)
+
+    api.start_move_object(manager, obj, (x_mm, y_mm))
+    api.set_preview_target(device_id, (x_mm, y_mm))
+    return jsonify({"status": "started"})
+
+
+@app.route("/preview_target", methods=["POST"])
+def preview_target_route():
+    data = request.get_json(silent=True) or {}
+    device_id = int(data.get("device_id", -1))
+    with api.lock:
+        manager = api.plotclocks.get(device_id)
+        if not isinstance(manager, ArenaManager):
+            return jsonify({"status": "error", "message": "invalid"}), 400
+
+    try:
+        x_mm = float(data.get("x"))
+        y_mm = float(data.get("y"))
+    except (TypeError, ValueError):
+        api.clear_preview_target(device_id)
+        return jsonify({"status": "ok"})
+
+    api.set_preview_target(device_id, (x_mm, y_mm))
+    return jsonify({"status": "ok"})
 
 
 @app.route("/send_cmd", methods=["POST"])

--- a/ball_example/detectors.py
+++ b/ball_example/detectors.py
@@ -41,13 +41,14 @@ class ArucoDetector:
 
                 cx = int(np.mean(pts[:, 0]))
                 cy = int(np.mean(pts[:, 1]))
-                if int(marker_id) in (0, 1):
+                m_id = int(marker_id)
+                if m_id in (0, 1):
                     markers.append(
-                        Obstacle(id=int(marker_id), corners=pts_int, center=(cx, cy))
+                        Obstacle(id=m_id, corners=pts_int, center=(cx, cy))
                     )
                 else:
                     markers.append(
-                        ArucoMarker(id=int(marker_id), corners=pts_int, center=(cx, cy))
+                        ArucoMarker(id=m_id, corners=pts_int, center=(cx, cy))
                     )
 
         if ids4 is not None:

--- a/ball_example/gadgets.py
+++ b/ball_example/gadgets.py
@@ -518,8 +518,11 @@ class ArenaManager(PlotClock):
         super().send_command(cmd_name, *params)
 
     # ------------------------------------------------------------------
-    def grab_and_release(self, obj: Union[Ball, Obstacle], target_x: float, target_y: float):
-        """Return a GrabAndRelease scenario for this arena manager."""
-        from .scenarios import GrabAndRelease
+    def move_object(self, obj: Union[Ball, Obstacle], target_x: float, target_y: float):
+        """Return a MoveObject scenario for this arena manager."""
+        from .scenarios import MoveObject
 
-        return GrabAndRelease(self, obj, (target_x, target_y))
+        return MoveObject(self, obj, (target_x, target_y))
+
+    # backwards compatibility
+    grab_and_release = move_object

--- a/ball_example/scenarios.py
+++ b/ball_example/scenarios.py
@@ -534,10 +534,12 @@ class StandingBallHitter(Scenario):
         return ["Start"]
 
 
-class GrabAndRelease(Scenario):
+class MoveObject(Scenario):
     """Move to an object, grab it, then move to a target and release."""
 
-    WAIT_TIME = 0.5  # seconds to wait after each move
+    #: seconds to wait between actions. This gives the PlotClock enough time to
+    #: physically move and actuate its gripper.
+    WAIT_TIME = 0.5
 
     def __init__(self, manager: "ArenaManager", obj: Union[Ball, Obstacle], target_mm: Tuple[float, float]):
         self.manager = manager
@@ -567,15 +569,36 @@ class GrabAndRelease(Scenario):
             self._step = 1
             return
 
-        # print grab after delay
+        # wait, then grab the object
         if self._step == 1 and now - self._last_time >= self.WAIT_TIME:
             print("GRAB")
-            self.manager.send_command(f"p.setXY({self.target_mm[0]}, {self.target_mm[1]})")
             self._last_time = now
             self._step = 2
             return
 
+        # after grabbing, move to the target
         if self._step == 2 and now - self._last_time >= self.WAIT_TIME:
+            self.manager.send_command(f"p.setXY({self.target_mm[0]}, {self.target_mm[1]})")
+            self._last_time = now
+            self._step = 3
+            return
+
+        # finally release the object once at the target
+        if self._step == 3 and now - self._last_time >= self.WAIT_TIME:
             print("RELEASE")
             self.finished = True
+
+    def get_extra_points(self):
+        if not self.manager.calibration:
+            return None
+        try:
+            pt = self.manager.mm_to_pixel(self.target_mm)
+        except RuntimeError:
+            return None
+        return [pt]
+
+    def get_extra_labels(self):
+        if not self.manager.calibration:
+            return None
+        return ["Target"]
 

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -152,6 +152,7 @@
 
     /* live stats */
     let idsInitialized = false;
+    let lastClockKey = '';
 
     async function updateStats(){
       try{
@@ -177,7 +178,7 @@
         } else {
           scSpan.textContent = 'None';
         }
-        renderClocks(d);
+        maybeRenderClocks(d);
 
         if(!d.scenario_loaded){
           startBtn.disabled = true;
@@ -203,6 +204,7 @@
     const calibBtn   = qs('#calibrate-all');
     const clockList  = qs('#clock-list');
     let clockIds     = [];
+    const moveInputs = {}; // persist move-object selections and coordinates
     const servoCmds = [
       'getAngle()',
       'setAngle(rad)',
@@ -245,22 +247,37 @@
     pollPicoLog();
     updateCmdList();
 
+    function maybeRenderClocks(info){
+      const active = info.active_modes || {};
+      const key = JSON.stringify({
+        g:(info.gadgets||[]).map(g=>[g.id,g.class,active[g.id]]),
+        b:(info.ball_details||[]).map(b=>b.id),
+        o:(info.markers||[]).filter(m=>m.type==='Obstacle').map(m=>m.id)
+      });
+      if(key === lastClockKey) return;
+      lastClockKey = key;
+      renderClocks(info);
+    }
+
     function renderClocks(info){
       clockList.innerHTML = '';
       if(!Array.isArray(info.gadgets)) return;
       const active = info.active_modes || {};
-      for(const g of info.gadgets){
+        for(const g of info.gadgets){
+        const rec = moveInputs[g.id] || {};
         if(g.class !== 'PlotClock' && g.class !== 'ArenaManager') continue;
         const div = document.createElement('div');
         div.className = 'clock-entry';
         const span = document.createElement('span');
         span.textContent = 'P' + g.id;
         div.appendChild(span);
-        const modes = [
-          ['attack','Attack'],
-          ['defend','Defend'],
-          ['hit_standing','Hit']
-        ];
+        const modes = g.class === 'ArenaManager'
+          ? [['move_object','Move Object']]
+          : [
+              ['attack','Attack'],
+              ['defend','Defend'],
+              ['hit_standing','Hit']
+            ];
         for(const [mode,label] of modes){
           const b = document.createElement('button');
           b.textContent = label;
@@ -273,8 +290,45 @@
               b.disabled = true;
             }
           }
-          b.addEventListener('click', ()=>toggleMode(g.id, mode));
-          div.appendChild(b);
+          if(g.class === 'ArenaManager'){
+            const objSel = document.createElement('select');
+            const xInput = document.createElement('input');
+            xInput.type = 'number';
+            xInput.placeholder = 'x';
+            xInput.style.width = '50px';
+            const yInput = document.createElement('input');
+            yInput.type = 'number';
+            yInput.placeholder = 'y';
+            yInput.style.width = '50px';
+            for(const ball of info.ball_details||[]){
+              const o = document.createElement('option');
+              o.value = 'ball:' + ball.id;
+              o.textContent = 'Ball ' + ball.id.slice(0,4);
+              objSel.appendChild(o);
+            }
+            for(const m of (info.markers||[])){
+              if(m.type === 'Obstacle'){
+                const o = document.createElement('option');
+                o.value = 'obs:' + m.id;
+                o.textContent = 'Obs ' + m.id;
+                objSel.appendChild(o);
+              }
+            }
+            objSel.value = rec.obj || objSel.value;
+            xInput.value = rec.x || '';
+            yInput.value = rec.y || '';
+            objSel.addEventListener('change', ()=>{ rec.obj = objSel.value; moveInputs[g.id] = rec; });
+            xInput.addEventListener('input', ()=>{ rec.x = xInput.value; moveInputs[g.id]=rec; previewTarget(g.id, xInput.value, yInput.value); });
+            yInput.addEventListener('input', ()=>{ rec.y = yInput.value; moveInputs[g.id]=rec; previewTarget(g.id, xInput.value, yInput.value); });
+            b.addEventListener('click', ()=>moveObject(g.id, objSel.value, xInput.value, yInput.value));
+            div.appendChild(b);
+            div.appendChild(objSel);
+            div.appendChild(xInput);
+            div.appendChild(yInput);
+          } else {
+            b.addEventListener('click', ()=>toggleMode(g.id, mode));
+            div.appendChild(b);
+          }
         }
         clockList.appendChild(div);
       }
@@ -383,6 +437,30 @@
           alert('Mode error: ' + (d.message||''));
         }
       }catch(e){ alert('Error: ' + e); }
+    }
+
+    async function moveObject(id, obj, x, y){
+      try{
+        const r = await fetch('/move_object', {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({device_id:id, object:obj, x:parseFloat(x), y:parseFloat(y)})
+        });
+        const d = await r.json();
+        if(d.status !== 'started'){
+          alert('Move error: ' + (d.message||''));
+        }
+      }catch(e){ alert('Error: ' + e); }
+    }
+
+    async function previewTarget(id, x, y){
+      try{
+        await fetch('/preview_target', {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({device_id:id, x:parseFloat(x), y:parseFloat(y)})
+        });
+      }catch(e){ console.error(e); }
     }
 
     /* Command box enter */

--- a/tests/test_game_api_move_object.py
+++ b/tests/test_game_api_move_object.py
@@ -1,0 +1,36 @@
+import os, sys
+import pytest
+
+pytest.importorskip("numpy")
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from ball_example.game_api import GameAPI
+from ball_example.gadgets import ArenaManager
+from ball_example.models import Ball
+
+
+def test_game_api_move_object_finish_clears_mode():
+    api = GameAPI()
+    mgr = ArenaManager(device_id=1)
+    mgr.calibration = {
+        "u_x": np.array([1.0, 0.0]),
+        "u_y": np.array([0.0, 1.0]),
+        "origin_px": (0, 0),
+    }
+    api.plotclocks[1] = mgr
+    ball = Ball((0, 0), 5)
+    api.balls.append(ball)
+    api.start_move_object(mgr, ball, (10, 20))
+    sc = api.clock_scenarios[1]
+    sc.on_start()
+
+    # complete scenario steps
+    for _ in range(4):
+        sc._last_time -= sc.WAIT_TIME + 0.1
+        api.update(np.zeros((10, 10, 3), dtype=np.uint8), [], [])
+
+    assert 1 not in api.clock_scenarios
+    assert 1 not in api.clock_modes
+

--- a/tests/test_grab_release.py
+++ b/tests/test_grab_release.py
@@ -9,7 +9,7 @@ from ball_example.gadgets import ArenaManager
 from ball_example.models import Ball, Obstacle
 
 
-def test_grab_and_release_commands():
+def test_move_object_ball():
     mgr = ArenaManager(device_id=1)
     mgr.calibration = {
         "u_x": np.array([1.0, 0.0]),
@@ -28,22 +28,32 @@ def test_grab_and_release_commands():
     mgr.master = master
 
     ball = Ball((10, 20), 5)
-    scenario = mgr.grab_and_release(ball, 100, 200)
+    scenario = mgr.move_object(ball, 100, 200)
     scenario.on_start()
+    assert scenario.get_extra_points() == [(100, 200)]
+    assert scenario.get_extra_labels() == ["Target"]
 
+    # step 0 -> move to ball
     scenario.update([])
     assert master.sent == ["P1.p.setXY(10, 20)"]
 
+    # step 1 -> grab (no command)
+    scenario._last_time -= scenario.WAIT_TIME + 0.1
+    scenario.update([])
+    assert master.sent == ["P1.p.setXY(10, 20)"]
+
+    # step 2 -> move to target
     scenario._last_time -= scenario.WAIT_TIME + 0.1
     scenario.update([])
     assert master.sent == ["P1.p.setXY(10, 20)", "P1.p.setXY(100, 200)"]
 
+    # step 3 -> release
     scenario._last_time -= scenario.WAIT_TIME + 0.1
     scenario.update([])
     assert scenario.finished
 
 
-def test_grab_and_release_obstacle():
+def test_move_object_obstacle():
     mgr = ArenaManager(device_id=1)
     mgr.calibration = {
         "u_x": np.array([1.0, 0.0]),
@@ -62,16 +72,26 @@ def test_grab_and_release_obstacle():
     mgr.master = master
 
     obs = Obstacle(0, [], (30, 40))
-    scenario = mgr.grab_and_release(obs, 100, 200)
+    scenario = mgr.move_object(obs, 100, 200)
     scenario.on_start()
+    assert scenario.get_extra_points() == [(100, 200)]
+    assert scenario.get_extra_labels() == ["Target"]
 
+    # step 0 -> move to object
     scenario.update([])
     assert master.sent == ["P1.p.setXY(30, 40)"]
 
+    # step 1 -> grab (no command)
+    scenario._last_time -= scenario.WAIT_TIME + 0.1
+    scenario.update([])
+    assert master.sent == ["P1.p.setXY(30, 40)"]
+
+    # step 2 -> move to target
     scenario._last_time -= scenario.WAIT_TIME + 0.1
     scenario.update([])
     assert master.sent == ["P1.p.setXY(30, 40)", "P1.p.setXY(100, 200)"]
 
+    # step 3 -> release
     scenario._last_time -= scenario.WAIT_TIME + 0.1
     scenario.update([])
     assert scenario.finished


### PR DESCRIPTION
## Summary
- keep preview marker after starting move-object and show it while running
- show scenario's target on annotated feed via `MoveObject.get_extra_*`
- auto-stop per-clock scenarios when finished so UI buttons reset
- unit tests for target overlay and scenario cleanup

## Testing
- `pytest -q` *(5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68613467b85083289edf2aa60053a8aa