### PR TITLE
Add move & hit demo scenario

### DIFF
--- a/ball_example/game_api.py
+++ b/ball_example/game_api.py
@@ -131,6 +131,8 @@ class GameAPI:
             labels = self._current_scenario.get_extra_labels()
             if labels:
                 extra_labels.extend(labels if isinstance(labels, list) else [labels])
+            if self._current_scenario.finished:
+                self.stop_scenario()
 
         finished_ids = []
         for dev_id, sc in list(self.clock_scenarios.items()):


### PR DESCRIPTION
## Summary
- implement `MoveBallHitRandom` scenario that moves a single ball to the hitter and strikes it toward a random point inside the arena
- create `SingleHitStandingBallHitter` helper for one‑off hits
- stop scenarios automatically once `finished` becomes true
- load the new scenario after connecting Pico
- expose `PlotClock` import in `app.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686179c247308328bccfbfdcf3a1367a