### PR TITLE
Fix MoveBallHitRandom target logic

### DIFF
--- a/ball_example/detectors.py
+++ b/ball_example/detectors.py
@@ -53,7 +53,7 @@ class ArucoDetector:
 
         if ids4 is not None:
             for marker_corners, marker_id in zip(corners4, ids4.flatten()):
-                if int(marker_id) not in range(0, 12):
+                if int(marker_id) not in range(0, 15):
                     continue  # ignore misdetected IDs
                 pts = marker_corners.reshape(-1, 2)
                 pts_int = [(int(x), int(y)) for x, y in pts]

--- a/ball_example/game_api.py
+++ b/ball_example/game_api.py
@@ -131,6 +131,8 @@ class GameAPI:
             labels = self._current_scenario.get_extra_labels()
             if labels:
                 extra_labels.extend(labels if isinstance(labels, list) else [labels])
+            if self._current_scenario.finished:
+                self.stop_scenario()
 
         finished_ids = []
         for dev_id, sc in list(self.clock_scenarios.items()):

--- a/ball_example/scenarios.py
+++ b/ball_example/scenarios.py
@@ -1,9 +1,10 @@
 import math
 import numpy as np
 import time
+import random
 from typing import List, Optional, Tuple, Union, Dict, Any
 from .models import Ball, Obstacle, ArucoMarker, ArucoHitter
-from .gadgets import PlotClock
+from .gadgets import PlotClock, ArenaManager
 
 
 class Scenario:
@@ -686,4 +687,179 @@ class MoveObject(Scenario):
         if not self.manager.calibration:
             return None
         return ["Target"]
+
+
+class SingleHitStandingBallHitter(StandingBallHitter):
+    """StandingBallHitter variant that finishes after a single strike."""
+
+    def on_start(self) -> None:
+        super().on_start()
+        self.finished = False
+
+    def update(self, detections) -> None:
+        super().update(detections)
+        if (
+            self._strike_time is not None
+            and not self._armed
+            and not self._fired
+        ):
+            self.finished = True
+
+
+class MoveBallHitRandom(Scenario):
+    """Move the lone ball to the hitter and strike toward a random target."""
+
+    PREVIEW_TIME = 1.0  # seconds
+
+    def __init__(self, manager: ArenaManager, hitter: PlotClock):
+        self.manager = manager
+        self.hitter = hitter
+        self.move_sc: MoveObject | None = None
+        self.hit_sc: SingleHitStandingBallHitter | None = None
+        self._step = 0
+        self._target_mm: Tuple[float, float] | None = None
+        self._preview_until = 0.0
+
+    def on_start(self) -> None:
+        self.finished = False
+        self.move_sc = None
+        self.hit_sc = None
+        self._step = 0
+        self._target_mm = None
+        self._preview_until = 0.0
+        print("[MoveBallHitRandom] started")
+
+    def on_stop(self) -> None:
+        print("[MoveBallHitRandom] stopped")
+
+    # ------------------------------------------------------------------
+    def _random_target_mm(self) -> Tuple[float, float]:
+        if (
+            isinstance(self.manager, ArenaManager)
+            and self.hitter.calibration
+        ):
+            poly = self.manager.get_working_area_polygon()
+            hitter_poly = self.hitter.get_working_area_polygon()
+            if len(poly) >= 3:
+                xs = [p[0] for p in poly]
+                ys = [p[1] for p in poly]
+                min_x, max_x = min(xs), max(xs)
+                min_y, max_y = min(ys), max(ys)
+                for _ in range(100):
+                    x = random.uniform(min_x, max_x)
+                    y = random.uniform(min_y, max_y)
+                    pt = (int(x), int(y))
+                    if ArenaManager._pt_in_poly(pt, poly) and not (
+                        hitter_poly and ArenaManager._pt_in_poly(pt, hitter_poly)
+                    ):
+                        break
+                else:
+                    # fallback to centre of arena
+                    x, y = (min_x + max_x) / 2, (min_y + max_y) / 2
+                return self.hitter.find_mm(int(x), int(y))
+
+        # fallback: choose a point outside the workspace bounds
+        for _ in range(100):
+            x = random.uniform(*self.hitter.x_range)
+            y = random.uniform(*self.hitter.y_range)
+            if (
+                abs(x) > self.hitter.max_x * 0.9
+                or y < self.hitter.min_y + (self.hitter.y_range[1] - self.hitter.min_y) * 0.1
+            ):
+                return (x, y)
+
+        # as last resort just return edge of workspace
+        return (
+            self.hitter.x_range[1],
+            self.hitter.y_range[0],
+        )
+
+    def _start_hit(self) -> None:
+        self._target_mm = self._random_target_mm()
+        self.hit_sc = SingleHitStandingBallHitter(self.hitter, self._target_mm)
+        self.hit_sc.on_start()
+        self._preview_until = time.time() + self.PREVIEW_TIME
+        print(f"[MoveBallHitRandom] hitting toward {self._target_mm}")
+
+    # ------------------------------------------------------------------
+    def update(self, detections) -> None:
+        if self.finished:
+            return
+
+        if self._step == 0:
+            if not (self.manager.calibration and self.hitter.calibration):
+                return
+            balls = [d for d in detections if isinstance(d, Ball)]
+            if len(balls) != 1:
+                return
+            ball = balls[0]
+            cx = (self.hitter.x_range[0] + self.hitter.x_range[1]) / 2
+            cy = (self.hitter.y_range[0] + self.hitter.y_range[1]) / 2
+            cx_px, cy_px = self.hitter.mm_to_pixel((cx, cy))
+            cx_mm, cy_mm = self.manager.find_mm(int(cx_px), int(cy_px))
+            self.move_sc = MoveObject(self.manager, ball, (cx_mm, cy_mm))
+            self.move_sc.on_start()
+            print("[MoveBallHitRandom] moving ball to hitter")
+            self._step = 1
+            return
+
+        if self._step == 1 and self.move_sc is not None:
+            self.move_sc.update(detections)
+            if self.move_sc.finished:
+                self._start_hit()
+                print("[MoveBallHitRandom] ball centered; preparing hit")
+                self._step = 2
+            return
+
+        if self._step == 2 and self.hit_sc is not None:
+            self.hit_sc.update(detections)
+            if time.time() >= self._preview_until and not self.hit_sc._armed:
+                self.hit_sc.process_message({"action": "start_hit"})
+            if self.hit_sc.finished:
+                print("[MoveBallHitRandom] hit complete")
+                self.finished = True
+
+    # ------------------------------------------------------------------
+    def get_line_points(self):
+        lines = []
+        if self.move_sc:
+            l = self.move_sc.get_line_points()
+            if l:
+                lines.extend(l if isinstance(l, list) else [l])
+        if self.hit_sc:
+            l = self.hit_sc.get_line_points()
+            if l:
+                lines.extend(l if isinstance(l, list) else [l])
+        return lines or None
+
+    def get_extra_points(self):
+        pts = []
+        if self.move_sc:
+            p = self.move_sc.get_extra_points()
+            if p:
+                pts.extend(p if isinstance(p, list) else [p])
+        if self.hit_sc:
+            p = self.hit_sc.get_extra_points()
+            if p:
+                pts.extend(p if isinstance(p, list) else [p])
+        if self._target_mm and self.hitter.calibration:
+            try:
+                pts.append(self.hitter.mm_to_pixel(self._target_mm))
+            except RuntimeError:
+                pass
+        return pts or None
+
+    def get_extra_labels(self):
+        labels = []
+        if self.move_sc:
+            l = self.move_sc.get_extra_labels()
+            if l:
+                labels.extend(l if isinstance(l, list) else [l])
+        if self.hit_sc:
+            l = self.hit_sc.get_extra_labels()
+            if l:
+                labels.extend(l if isinstance(l, list) else [l])
+        if self._target_mm:
+            labels.append("Target")
+        return labels or None
 

--- a/ball_example/scenarios.py
+++ b/ball_example/scenarios.py
@@ -672,6 +672,8 @@ class MoveObject(Scenario):
         # finally release the object once at the target
         if self._step == 3 and now - self._last_time >= self.WAIT_TIME:
             print("RELEASE")
+            wx, wy = self.manager.wait_position_mm()
+            self.manager.send_command(f"p.setXY({wx}, {wy})")
             self.finished = True
 
     def get_extra_points(self):
@@ -711,6 +713,9 @@ class MoveBallHitRandom(Scenario):
 
     PREVIEW_TIME = 1.0  # seconds
 
+    STABLE_TIME = 0.5  # seconds ball must stay still
+    STABLE_VEL_PF = 0.5  # px/frame considered "still"
+
     def __init__(self, manager: ArenaManager, hitter: PlotClock):
         self.manager = manager
         self.hitter = hitter
@@ -719,6 +724,7 @@ class MoveBallHitRandom(Scenario):
         self._step = 0
         self._target_mm: Tuple[float, float] | None = None
         self._preview_until = 0.0
+        self._stable_start: float | None = None
 
     def on_start(self) -> None:
         self.finished = False
@@ -727,6 +733,7 @@ class MoveBallHitRandom(Scenario):
         self._step = 0
         self._target_mm = None
         self._preview_until = 0.0
+        self._stable_start = None
         print("[MoveBallHitRandom] started")
 
     def on_stop(self) -> None:
@@ -806,12 +813,27 @@ class MoveBallHitRandom(Scenario):
         if self._step == 1 and self.move_sc is not None:
             self.move_sc.update(detections)
             if self.move_sc.finished:
-                self._start_hit()
-                print("[MoveBallHitRandom] ball centered; preparing hit")
+                print("[MoveBallHitRandom] ball centered; waiting stability")
                 self._step = 2
             return
 
-        if self._step == 2 and self.hit_sc is not None:
+        if self._step == 2:
+            balls = [d for d in detections if isinstance(d, Ball)]
+            if len(balls) != 1 or not self.hitter.calibration:
+                return
+            poly = self.hitter.get_working_area_polygon()
+            if len(poly) >= 3 and ArenaManager._pt_in_poly(balls[0].center, poly) and math.hypot(*balls[0].velocity) < self.STABLE_VEL_PF:
+                if self._stable_start is None:
+                    self._stable_start = time.time()
+                elif time.time() - self._stable_start >= self.STABLE_TIME:
+                    self._start_hit()
+                    print("[MoveBallHitRandom] preparing hit")
+                    self._step = 3
+            else:
+                self._stable_start = None
+            return
+
+        if self._step == 3 and self.hit_sc is not None:
             self.hit_sc.update(detections)
             if time.time() >= self._preview_until and not self.hit_sc._armed:
                 self.hit_sc.process_message({"action": "start_hit"})


### PR DESCRIPTION
## Summary
- make MoveBallHitRandom pick random target outside the hitter workspace
- keep scenario behaviour for moving the ball and hitting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686179c247308328bccfbfdcf3a1367a