### PR TITLE
Update ArenaManager calibration logic

### DIFF
--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,4 +1,4 @@
-import os, sys, time, types, pytest
+import os, sys, types, pytest
 
 pytest.importorskip("numpy")
 
@@ -12,23 +12,33 @@ sys.modules.setdefault("serial", serial_stub)
 sys.modules.setdefault("serial.tools", serial_stub.tools)
 sys.modules.setdefault("serial.tools.list_ports", serial_stub.tools.list_ports)
 
+import numpy as np
+
 from ball_example.gadgets import ArenaManager
-from ball_example.models import ArucoManager
+from ball_example.models import ArucoMarker, ArucoManager
 
-def _marker(center=(0,0)):
-    return ArucoManager(1, [(0,0)]*4, center)
 
-def test_arena_manager_calibration_progresses():
-    clock = ArenaManager()
-    clock._delay = 0
-    clock.send_command = lambda *a, **k: None
-    # first call sends move to first point
-    clock.calibrate([])
-    assert clock._cal_state == 1
-    # provide marker detections for remaining states
-    for i in range(3):
-        clock._last_cmd_t = time.time() - 1
-        clock.calibrate([_marker((i, i))])
-    assert clock.calibration is not None
+def _servo(center=(0, 0)):
+    return ArucoMarker(47, [(0, 0)] * 4, center)
+
+
+def _manager(center=(0, 0)):
+    return ArucoManager(0, [(0, 0)] * 4, center)
+
+
+def test_arena_manager_calibration_new_logic():
+    mgr = ArenaManager()
+    dets = [
+        _servo((10, 20)),
+        _servo((110, 20)),
+        _manager((60, 120)),
+    ]
+
+    cal = mgr.calibrate(dets)
+    assert cal is not None
+    assert pytest.approx(cal["servo_px_dist"], rel=1e-6) == 100.0
+    np.testing.assert_allclose(cal["u_x"], np.array([100 / 148.0, 0.0]), atol=1e-6)
+    np.testing.assert_allclose(cal["u_y"], np.array([0.0, 100 / 148.0]), atol=1e-6)
+    assert cal["origin_px"] == (60, 20)
 
 


### PR DESCRIPTION
## Summary
- implement new calibration logic for ArenaManager using two id 47 markers
- draw axes even when an arena polygon is present
- add tests for new calibration logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863c44ff04c833381360ce65261954c