### PR TITLE
Add grip/release actions to manager

### DIFF
--- a/ball_example/gadgets.py
+++ b/ball_example/gadgets.py
@@ -477,6 +477,14 @@ class ArenaManager(PlotClock):
     calibration_marker_cls = ArucoManager
     SERVO_MM_DIST: float = 148.0
 
+    def grip(self) -> None:
+        """Close the manager's gripper."""
+        self.send_command("p.grip()")
+
+    def release(self) -> None:
+        """Open the manager's gripper."""
+        self.send_command("p.release()")
+
     def __init__(self, *args, arena: Optional[Arena] = None, coeffs_path: str | None = None, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.arena: Optional[Arena] = arena

--- a/ball_example/scenarios.py
+++ b/ball_example/scenarios.py
@@ -651,7 +651,7 @@ class MoveObject(Scenario):
 
         # wait, then grab the object
         if self._step == 1 and now - self._last_time >= self.WAIT_TIME:
-            print("GRAB")
+            self.manager.grip()
             self._last_time = now
             self._step = 2
             return
@@ -668,7 +668,7 @@ class MoveObject(Scenario):
 
         # finally release the object once at the target
         if self._step == 3 and now - self._last_time >= self.WAIT_TIME:
-            print("RELEASE")
+            self.manager.release()
             wx, wy = self.manager.wait_position_mm()
             self.manager.setXY_updated_manager(wx, wy)
             self.finished = True

--- a/tests/test_grab_release.py
+++ b/tests/test_grab_release.py
@@ -37,19 +37,20 @@ def test_move_object_ball():
     scenario.update([])
     assert master.sent == ["P1.p.setXY(10, 20)"]
 
-    # step 1 -> grab (no command)
+    # step 1 -> grab
     scenario._last_time -= scenario.WAIT_TIME + 0.1
     scenario.update([])
-    assert master.sent == ["P1.p.setXY(10, 20)"]
+    assert master.sent == ["P1.p.setXY(10, 20)", "P1.p.grip()"]
 
     # step 2 -> move to target
     scenario._last_time -= scenario.WAIT_TIME + 0.1
     scenario.update([])
-    assert master.sent == ["P1.p.setXY(10, 20)", "P1.p.setXY(100, 200)"]
+    assert master.sent == ["P1.p.setXY(10, 20)", "P1.p.grip()", "P1.p.setXY(100, 200)"]
 
     # step 3 -> release
     scenario._last_time -= scenario.WAIT_TIME + 0.1
     scenario.update([])
+    assert master.sent[-2].startswith("P1.p.release()")
     assert scenario.finished
 
 
@@ -81,17 +82,18 @@ def test_move_object_obstacle():
     scenario.update([])
     assert master.sent == ["P1.p.setXY(30, 40)"]
 
-    # step 1 -> grab (no command)
+    # step 1 -> grab
     scenario._last_time -= scenario.WAIT_TIME + 0.1
     scenario.update([])
-    assert master.sent == ["P1.p.setXY(30, 40)"]
+    assert master.sent == ["P1.p.setXY(30, 40)", "P1.p.grip()"]
 
     # step 2 -> move to target
     scenario._last_time -= scenario.WAIT_TIME + 0.1
     scenario.update([])
-    assert master.sent == ["P1.p.setXY(30, 40)", "P1.p.setXY(100, 200)"]
+    assert master.sent == ["P1.p.setXY(30, 40)", "P1.p.grip()", "P1.p.setXY(100, 200)"]
 
     # step 3 -> release
     scenario._last_time -= scenario.WAIT_TIME + 0.1
     scenario.update([])
+    assert master.sent[-2].startswith("P1.p.release()")
     assert scenario.finished


### PR DESCRIPTION
## Summary
- expose `grip()` and `release()` helpers on `ArenaManager`
- use these in `MoveObject` scenario
- update grab/release tests for new commands

## Testing
- `pytest -q tests/test_grab_release.py -vv` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68642d3a34448328998042e50efeadc5