### PR TITLE
Add unique labels for obstacles and targets

### DIFF
--- a/PlotClock/PlotClockSlave.py
+++ b/PlotClock/PlotClockSlave.py
@@ -211,15 +211,7 @@ def parse_command(cmd):
     try:
         obj_name, sep2, method_part = code_part.partition(".")
         if obj_name in device_objects:
-            # handle simple gripper commands explicitly
-            if method_part == "grip()":
-                device_objects[obj_name].grip()
-                result = None
-            elif method_part == "release()":
-                device_objects[obj_name].release()
-                result = None
-            else:
-                result = eval(f'device_objects["{obj_name}"].{method_part}')
+            result = eval(f'device_objects["{obj_name}"].{method_part}')
             if result is not None:
                 uart.write(f"{DEVICE_ID}:{str(result)}\n".encode())  # Güvenli encode
         else:

--- a/PlotClock/PlotClockSlave.py
+++ b/PlotClock/PlotClockSlave.py
@@ -2,8 +2,6 @@ import machine
 import math
 import utime
 
-
-
 utime.sleep_ms(1000	)
 
 DEVICE_ID = "P1"
@@ -30,11 +28,12 @@ class Servo:
     def calibrateRotation(self,factor): 
         self.factor = factor
         self.setAngle(0)
-        wait_ms(2000)
+        wait_ms(3000)
         self.setAngle(math.pi/2)
-        wait_ms(2000)
+        wait_ms(3000)
         self.setAngle(math.pi)
-        wait_ms(2000)
+        wait_ms(3000)
+
 
 class PlotClock:
     def __init__(self,servoLeft,servoRight,L1,L2,L3,L4,hitDia,servoMarginAngle = 2.5/180*math.pi):
@@ -89,16 +88,13 @@ class PlotClock:
 
     def getStartAngle(self):
         return self.startAngle
-
+    
     def getL1(self):
         return self.L1
-
     def getL2(self):
         return self.L2
-
     def getL3(self):
         return self.L3
-
     def getL4(self):
         return self.L4
     
@@ -106,6 +102,7 @@ class PlotClock:
         self.servoLeft.startPose = leftStartPose
         self.servoRight.startPose = rightStartPose
         self.goHome()
+    
 
     def goHome(self):
 
@@ -190,13 +187,14 @@ def wait_ms(ms):
 uart = machine.UART(0, baudrate=115200, tx=machine.Pin(0), rx=machine.Pin(1))
 
 
-#servoLeft = Servo(4,975,1000)
-#servoRight = Servo(3,1000,1025)
-#plotClock = PlotClock(servoLeft, servoRight,65,95,25,30,20)
+servoLeft = Servo(5,975,990)
+servoRight = Servo(2,1000,1005)
+plotClock = PlotClock(servoLeft, servoRight,65,95,25,30,20)
 
-servoLeft = Servo(4,950,1040)
-servoRight = Servo(3,950,930)
-plotClock = PlotClock(servoLeft, servoRight,270,328,150,98,20)
+
+#servoLeft = Servo(4,950,1040)
+#servoRight = Servo(3,950,930)
+#plotClock = PlotClock(servoLeft, servoRight,270,328,150,98,20)
 
 device_objects = {
     'p': plotClock,
@@ -243,14 +241,21 @@ led_on = False
 interval = 500  # milisaniye
 last_toggle_time = utime.ticks_ms()
 
-# Home then move to idle position
-plotClock.goHome()
-plotClock.gotoXY(0, 110)
+
+plotClock.gotoXY(0,60)
+# wait_ms(1000)
+# plotClock.goHome()
+# wait_ms(1000)
+# plotClock.gotoXY(0,100)
+
+
 uart.write(f"{DEVICE_ID}:READY\n".encode())  # Cihaz hazır mesajı
 
 while True:
     buffer = readCommand(buffer)
     plotClock.update()
+    #plotClock.goHome()
+    
 
     current_time = utime.ticks_ms()
     if utime.ticks_diff(current_time, last_toggle_time) >= interval:

--- a/PlotClock/PlotClockSlave.py
+++ b/PlotClock/PlotClockSlave.py
@@ -245,7 +245,7 @@ last_toggle_time = utime.ticks_ms()
 
 # Home then move to idle position
 plotClock.goHome()
-plotClock.gotoXY(0, 60)
+plotClock.gotoXY(0, 110)
 uart.write(f"{DEVICE_ID}:READY\n".encode())  # Cihaz hazır mesajı
 
 while True:

--- a/PlotClock/PlotClockSlave.py
+++ b/PlotClock/PlotClockSlave.py
@@ -211,7 +211,15 @@ def parse_command(cmd):
     try:
         obj_name, sep2, method_part = code_part.partition(".")
         if obj_name in device_objects:
-            result = eval(f'device_objects["{obj_name}"].{method_part}')
+            # handle simple gripper commands explicitly
+            if method_part == "grip()":
+                device_objects[obj_name].grip()
+                result = None
+            elif method_part == "release()":
+                device_objects[obj_name].release()
+                result = None
+            else:
+                result = eval(f'device_objects["{obj_name}"].{method_part}')
             if result is not None:
                 uart.write(f"{DEVICE_ID}:{str(result)}\n".encode())  # Güvenli encode
         else:
@@ -243,7 +251,9 @@ led_on = False
 interval = 500  # milisaniye
 last_toggle_time = utime.ticks_ms()
 
+# Home then move to idle position
 plotClock.goHome()
+plotClock.gotoXY(0, 60)
 uart.write(f"{DEVICE_ID}:READY\n".encode())  # Cihaz hazır mesajı
 
 while True:

--- a/PlotClock/arena_manager_slave.py
+++ b/PlotClock/arena_manager_slave.py
@@ -195,7 +195,7 @@ class PlotClock:
     def grip_smooth(self, end_angle=50, step=5, delay=0.01):
         if self.gripper_servo is None:
             return
-        for angle in range(180, end_angle - 1, -step):
+        for angle in range(180, end_angle - 3, -step):
             self._set_gripper_angle(angle)
             utime.sleep(delay)
 
@@ -225,11 +225,11 @@ uart = machine.UART(0, baudrate=115200, tx=machine.Pin(0), rx=machine.Pin(1))
 #servoRight = Servo(3,1000,1025)
 #plotClock = PlotClock(servoLeft, servoRight,65,95,25,30,20)
 
-servoLeft = Servo(4,980,1030)
-servoRight = Servo(3,960,915)
+servoLeft = Servo(5,980,1030)
+servoRight = Servo(2,960,915)
 plotClock = PlotClock(servoLeft, servoRight, 267,328,148,98,20)
 
-gripper_servo = machine.PWM(machine.Pin(5))
+gripper_servo = machine.PWM(machine.Pin(7))
 gripper_servo.freq(50)
 plotClock.gripper_servo = gripper_servo
 plotClock.release()
@@ -279,8 +279,11 @@ led_on = False
 interval = 500  # milisaniye
 last_toggle_time = utime.ticks_ms()
 
-# Move to a convenient idle location after boot
 plotClock.gotoXY(0, 250)
+# plotClock.release_smooth()
+# wait_ms(4000)
+# plotClock.grip_smooth()
+
 
 uart.write(f"{DEVICE_ID}:READY\n".encode())  # Cihaz hazır mesajı
 
@@ -294,6 +297,3 @@ while True:
         led_on = not led_on
         led.value(led_on)
         last_toggle_time = current_time
-
-
-

--- a/PlotClock/arena_manager_slave.py
+++ b/PlotClock/arena_manager_slave.py
@@ -192,14 +192,14 @@ class PlotClock:
     def release(self):
         self._set_gripper_angle(180)
 
-    def grip_smooth(self, end_angle=50, step=1, delay=0.02):
+    def grip_smooth(self, end_angle=50, step=5, delay=0.01):
         if self.gripper_servo is None:
             return
         for angle in range(180, end_angle - 1, -step):
             self._set_gripper_angle(angle)
             utime.sleep(delay)
 
-    def release_smooth(self, end_angle=180, step=1, delay=0.02):
+    def release_smooth(self, end_angle=180, step=2, delay=0.01):
         if self.gripper_servo is None:
             return
         for angle in range(50, end_angle + 1, step):

--- a/PlotClock/arena_manager_slave.py
+++ b/PlotClock/arena_manager_slave.py
@@ -202,6 +202,17 @@ class PlotClock:
         for angle in angles:
             self._set_gripper_angle(angle)
             utime.sleep(delay)
+
+    def release_smooth(self, start_angle, end_angle, step=1, delay=0.02):
+        if self.gripper_servo is None:
+            return
+        if start_angle < end_angle:
+            angles = range(start_angle, end_angle + 1, step)
+        else:
+            angles = range(start_angle, end_angle - 1, -step)
+        for angle in angles:
+            self._set_gripper_angle(angle)
+            utime.sleep(delay)
                
     
 def cosTheomAng(adjacentSide1, adjacentSide2, oppositeSide):

--- a/PlotClock/arena_manager_slave.py
+++ b/PlotClock/arena_manager_slave.py
@@ -247,7 +247,15 @@ def parse_command(cmd):
     try:
         obj_name, sep2, method_part = code_part.partition(".")
         if obj_name in device_objects:
-            result = eval(f'device_objects["{obj_name}"].{method_part}')
+            # special-case simple gripper commands for robustness
+            if method_part == "grip()":
+                device_objects[obj_name].grip()
+                result = None
+            elif method_part == "release()":
+                device_objects[obj_name].release()
+                result = None
+            else:
+                result = eval(f'device_objects["{obj_name}"].{method_part}')
             if result is not None:
                 uart.write(f"{DEVICE_ID}:{str(result)}\n".encode())  # Güvenli encode
         else:
@@ -279,7 +287,8 @@ led_on = False
 interval = 500  # milisaniye
 last_toggle_time = utime.ticks_ms()
 
-plotClock.gotoXY(0, 200)
+# Move to a convenient idle location after boot
+plotClock.gotoXY(0, 250)
 
 uart.write(f"{DEVICE_ID}:READY\n".encode())  # Cihaz hazır mesajı
 

--- a/PlotClock/arena_manager_slave.py
+++ b/PlotClock/arena_manager_slave.py
@@ -247,15 +247,7 @@ def parse_command(cmd):
     try:
         obj_name, sep2, method_part = code_part.partition(".")
         if obj_name in device_objects:
-            # special-case simple gripper commands for robustness
-            if method_part == "grip()":
-                device_objects[obj_name].grip()
-                result = None
-            elif method_part == "release()":
-                device_objects[obj_name].release()
-                result = None
-            else:
-                result = eval(f'device_objects["{obj_name}"].{method_part}')
+            result = eval(f'device_objects["{obj_name}"].{method_part}')
             if result is not None:
                 uart.write(f"{DEVICE_ID}:{str(result)}\n".encode())  # Güvenli encode
         else:

--- a/PlotClock/arena_manager_slave.py
+++ b/PlotClock/arena_manager_slave.py
@@ -192,25 +192,17 @@ class PlotClock:
     def release(self):
         self._set_gripper_angle(180)
 
-    def grip_smooth(self, start_angle, end_angle, step=1, delay=0.02):
+    def grip_smooth(self, end_angle=50, step=1, delay=0.02):
         if self.gripper_servo is None:
             return
-        if start_angle < end_angle:
-            angles = range(start_angle, end_angle + 1, step)
-        else:
-            angles = range(start_angle, end_angle - 1, -step)
-        for angle in angles:
+        for angle in range(180, end_angle - 1, -step):
             self._set_gripper_angle(angle)
             utime.sleep(delay)
 
-    def release_smooth(self, start_angle, end_angle, step=1, delay=0.02):
+    def release_smooth(self, end_angle=180, step=1, delay=0.02):
         if self.gripper_servo is None:
             return
-        if start_angle < end_angle:
-            angles = range(start_angle, end_angle + 1, step)
-        else:
-            angles = range(start_angle, end_angle - 1, -step)
-        for angle in angles:
+        for angle in range(50, end_angle + 1, step):
             self._set_gripper_angle(angle)
             utime.sleep(delay)
                

--- a/ball_example/app.py
+++ b/ball_example/app.py
@@ -11,7 +11,7 @@ if __package__ in (None, ""):
 
 from .game_api import GameAPI
 from .detectors import BallDetector
-from .models import ArucoWall, Arena, Obstacle
+from .models import ArucoWall, Arena, Obstacle, PhysicalTarget
 from .gadgets import ArenaManager, PlotClock
 from high_level import calibrate_clocks, draw_arena
 
@@ -332,7 +332,12 @@ def move_object_route():
             obj = next((b for b in api.balls if b.id == bid), None)
         elif obj_spec.startswith("obs:"):
             oid = int(obj_spec.split(":", 1)[1])
-            obj = next((m for m in api.arucos if isinstance(m, Obstacle) and m.id == oid), None)
+            obstacles = [m for m in api.arucos if isinstance(m, Obstacle)]
+            obj = obstacles[oid] if 0 <= oid < len(obstacles) else None
+        elif obj_spec.startswith("tgt:"):
+            tid = int(obj_spec.split(":", 1)[1])
+            targets = [m for m in api.arucos if isinstance(m, PhysicalTarget)]
+            obj = targets[tid] if 0 <= tid < len(targets) else None
         else:
             obj = None
 

--- a/ball_example/gadgets.py
+++ b/ball_example/gadgets.py
@@ -136,6 +136,8 @@ class PlotClock(Gadgets):
     # Construction / serial helpers
     # ──────────────────────────────────────────────────────────
     calibration_marker_cls = ArucoHitter
+    # Default idle location within the workspace
+    WAIT_POS_MM: Tuple[float, float] | None = (0.0, 60.0)
 
     def __init__(
         self,
@@ -398,6 +400,8 @@ class PlotClock(Gadgets):
 
     def wait_position_mm(self) -> Tuple[float, float]:
         """Return a safe waiting (x,y) inside the workspace."""
+        if self.WAIT_POS_MM is not None:
+            return self.WAIT_POS_MM
         return (0.0, self.min_y + self.cal_margin_mm)
 
     def draw_working_area(
@@ -484,6 +488,7 @@ class ArenaManager(PlotClock):
     """
 
     calibration_marker_cls = ArucoManager
+    WAIT_POS_MM: Tuple[float, float] | None = (0.0, 250.0)
     SERVO_MM_DIST: float = 148.0
 
     def grip(self) -> None:

--- a/ball_example/gadgets.py
+++ b/ball_example/gadgets.py
@@ -137,7 +137,7 @@ class PlotClock(Gadgets):
     # ──────────────────────────────────────────────────────────
     calibration_marker_cls = ArucoHitter
     # Default idle location within the workspace
-    WAIT_POS_MM: Tuple[float, float] | None = (0.0, 60.0)
+    WAIT_POS_MM: Tuple[float, float] | None = (0.0, 110.0)
 
     def __init__(
         self,
@@ -499,11 +499,11 @@ class ArenaManager(PlotClock):
         """Open the manager's gripper."""
         self.send_command("p.release()")
 
-    def grip_smooth(self, end: int = 50, step: int = 1, delay: float = 0.02) -> None:
+    def grip_smooth(self, end: int = 50, step: int = 5, delay: float = 0.01) -> None:
         """Smoothly close the gripper to ``end`` angle."""
         self.send_command(f"p.grip_smooth({end},{step},{delay})")
 
-    def release_smooth(self, end: int = 180, step: int = 1, delay: float = 0.02) -> None:
+    def release_smooth(self, end: int = 180, step: int = 2, delay: float = 0.01) -> None:
         """Smoothly open the gripper to ``end`` angle."""
         self.send_command(f"p.release_smooth({end},{step},{delay})")
 
@@ -615,7 +615,7 @@ class ArenaManager(PlotClock):
             p1 = np.array(servos[0].center, dtype=float)
             p2 = np.array(servos[1].center, dtype=float)
             mid = (p1 + p2) / 2.0
-            dx = -abs(p2 - p1)
+            dx = abs(p2 - p1)
             px_dist = float(np.linalg.norm(dx))
             if px_dist < 1e-6:
                 return None

--- a/ball_example/gadgets.py
+++ b/ball_example/gadgets.py
@@ -494,13 +494,13 @@ class ArenaManager(PlotClock):
         """Open the manager's gripper."""
         self.send_command("p.release()")
 
-    def grip_smooth(self, start: int = 180, end: int = 50, step: int = 1, delay: float = 0.02) -> None:
-        """Smoothly close the gripper from ``start`` to ``end`` angle."""
-        self.send_command(f"p.grip_smooth({start},{end},{step},{delay})")
+    def grip_smooth(self, end: int = 50, step: int = 1, delay: float = 0.02) -> None:
+        """Smoothly close the gripper to ``end`` angle."""
+        self.send_command(f"p.grip_smooth({end},{step},{delay})")
 
-    def release_smooth(self, start: int = 50, end: int = 180, step: int = 1, delay: float = 0.02) -> None:
-        """Smoothly open the gripper from ``start`` to ``end`` angle."""
-        self.send_command(f"p.release_smooth({start},{end},{step},{delay})")
+    def release_smooth(self, end: int = 180, step: int = 1, delay: float = 0.02) -> None:
+        """Smoothly open the gripper to ``end`` angle."""
+        self.send_command(f"p.release_smooth({end},{step},{delay})")
 
     def __init__(self, *args, arena: Optional[Arena] = None, coeffs_path: str | None = None, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/ball_example/gadgets.py
+++ b/ball_example/gadgets.py
@@ -494,6 +494,14 @@ class ArenaManager(PlotClock):
         """Open the manager's gripper."""
         self.send_command("p.release()")
 
+    def grip_smooth(self, start: int = 180, end: int = 50, step: int = 1, delay: float = 0.02) -> None:
+        """Smoothly close the gripper from ``start`` to ``end`` angle."""
+        self.send_command(f"p.grip_smooth({start},{end},{step},{delay})")
+
+    def release_smooth(self, start: int = 50, end: int = 180, step: int = 1, delay: float = 0.02) -> None:
+        """Smoothly open the gripper from ``start`` to ``end`` angle."""
+        self.send_command(f"p.release_smooth({start},{end},{step},{delay})")
+
     def __init__(self, *args, arena: Optional[Arena] = None, coeffs_path: str | None = None, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.arena: Optional[Arena] = arena

--- a/ball_example/game_api.py
+++ b/ball_example/game_api.py
@@ -350,7 +350,7 @@ class GameAPI:
             elif mtype == "PhysicalTarget":
                 counts["PhysicalTarget"] += 1
                 details["index"] = counts["PhysicalTarget"]
-                details["label"] = f"Target {counts['PhysicalTarget']}"
+                details["label"] = f"P. Target {counts['PhysicalTarget']}"
             marker_details.append(details)
 
         gadget_details = []

--- a/ball_example/game_api.py
+++ b/ball_example/game_api.py
@@ -333,15 +333,25 @@ class GameAPI:
             "scenario_name": scenario_name,
         }
 
-        marker_details = [
-            {
+        counts = {"Obstacle": 0, "PhysicalTarget": 0}
+        marker_details = []
+        for m in markers:
+            mtype = m.__class__.__name__
+            details = {
                 "id": m.id,
                 "center": m.center,
                 "corners": m.corners,
-                "type": m.__class__.__name__,
+                "type": mtype,
             }
-            for m in markers
-        ]
+            if mtype == "Obstacle":
+                counts["Obstacle"] += 1
+                details["index"] = counts["Obstacle"]
+                details["label"] = f"Obstacle {counts['Obstacle']}"
+            elif mtype == "PhysicalTarget":
+                counts["PhysicalTarget"] += 1
+                details["index"] = counts["PhysicalTarget"]
+                details["label"] = f"Target {counts['PhysicalTarget']}"
+            marker_details.append(details)
 
         gadget_details = []
         for g in self.plotclocks.values():

--- a/ball_example/high_level.py
+++ b/ball_example/high_level.py
@@ -75,6 +75,15 @@ def calibrate_clocks(
             break
         time.sleep(0.05)
 
+    # Move each clock to its idle waiting position after calibration
+    for c in clocks:
+        if c.calibration:
+            wx, wy = c.wait_position_mm()
+            if isinstance(c, ArenaManager):
+                c.setXY_updated_manager(wx, wy)
+            else:
+                c.send_command(f"p.setXY({wx}, {wy})")
+
 
 def draw_arena(frame, arena: Arena | List[ArucoWall]) -> None:
     """Draw an arena based on ArucoWall markers onto ``frame``."""

--- a/ball_example/scenarios.py
+++ b/ball_example/scenarios.py
@@ -807,8 +807,8 @@ class MoveBallHitRandom(Scenario):
             if len(balls) != 1:
                 return
             ball = balls[0]
-            cx = (self.hitter.x_range[0] + self.hitter.x_range[1]) / 2
-            cy = (self.hitter.y_range[0] + self.hitter.y_range[1]) / 2
+            cx = (self.hitter.x_range[0] + self.hitter.x_range[1]) * 9 / 16
+            cy = (self.hitter.y_range[0] + self.hitter.y_range[1]) * 9 / 16
             cx_px, cy_px = self.hitter.mm_to_pixel((cx, cy))
             cx_mm, cy_mm = self.manager.find_mm(int(cx_px), int(cy_px))
             self.move_sc = MoveObject(self.manager, ball, (cx_mm, cy_mm))

--- a/ball_example/scenarios.py
+++ b/ball_example/scenarios.py
@@ -651,7 +651,7 @@ class MoveObject(Scenario):
 
         # wait, then grab the object
         if self._step == 1 and now - self._last_time >= self.WAIT_TIME:
-            self.manager.grip_smooth()
+            self.manager.grip()
             self._last_time = now
             self._step = 2
             return

--- a/ball_example/scenarios.py
+++ b/ball_example/scenarios.py
@@ -651,7 +651,7 @@ class MoveObject(Scenario):
 
         # wait, then grab the object
         if self._step == 1 and now - self._last_time >= self.WAIT_TIME:
-            self.manager.grip()
+            self.manager.grip_smooth(180, 50)
             self._last_time = now
             self._step = 2
             return
@@ -668,7 +668,7 @@ class MoveObject(Scenario):
 
         # finally release the object once at the target
         if self._step == 3 and now - self._last_time >= self.WAIT_TIME:
-            self.manager.release()
+            self.manager.release_smooth(50, 180)
             wx, wy = self.manager.wait_position_mm()
             self.manager.setXY_updated_manager(wx, wy)
             self.finished = True

--- a/ball_example/scenarios.py
+++ b/ball_example/scenarios.py
@@ -651,7 +651,7 @@ class MoveObject(Scenario):
 
         # wait, then grab the object
         if self._step == 1 and now - self._last_time >= self.WAIT_TIME:
-            self.manager.grip_smooth(180, 50)
+            self.manager.grip_smooth()
             self._last_time = now
             self._step = 2
             return
@@ -668,7 +668,7 @@ class MoveObject(Scenario):
 
         # finally release the object once at the target
         if self._step == 3 and now - self._last_time >= self.WAIT_TIME:
-            self.manager.release_smooth(50, 180)
+            self.manager.release_smooth()
             wx, wy = self.manager.wait_position_mm()
             self.manager.setXY_updated_manager(wx, wy)
             self.finished = True

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -186,8 +186,8 @@
       'gotoXY()','setXY()','setXYrel()',
       'getL1()','getL2()','getL3()','getL4()',
       'grip()','release()',
-      'grip_smooth(end_angle=50,step=1,delay=0.02)',
-      'release_smooth(end_angle=180,step=1,delay=0.02)'
+      'grip_smooth(end=50,step=5,delay=0.01)',
+      'release_smooth(end=180,step=2,delay=0.01)'
     ];
 
     /* -------- live stats ------------------------------------------------- */

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -184,7 +184,8 @@
       'getXY()','getMaxX()','getMinY()','getStartAngle()',
       'startPoseCalibration()','goHome()','checkTarget()',
       'gotoXY()','setXY()','setXYrel()',
-      'getL1()','getL2()','getL3()','getL4()'
+      'getL1()','getL2()','getL3()','getL4()',
+      'grip()','release()','grip_smooth(start,end,step=1,delay=0.02)'
     ];
 
     /* -------- live stats ------------------------------------------------- */

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -185,7 +185,9 @@
       'startPoseCalibration()','goHome()','checkTarget()',
       'gotoXY()','setXY()','setXYrel()',
       'getL1()','getL2()','getL3()','getL4()',
-      'grip()','release()','grip_smooth(start,end,step=1,delay=0.02)'
+      'grip()','release()',
+      'grip_smooth(start,end,step=1,delay=0.02)',
+      'release_smooth(start,end,step=1,delay=0.02)'
     ];
 
     /* -------- live stats ------------------------------------------------- */

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -186,8 +186,8 @@
       'gotoXY()','setXY()','setXYrel()',
       'getL1()','getL2()','getL3()','getL4()',
       'grip()','release()',
-      'grip_smooth(start,end,step=1,delay=0.02)',
-      'release_smooth(start,end,step=1,delay=0.02)'
+      'grip_smooth(end=50,step=1,delay=0.02)',
+      'release_smooth(end=180,step=1,delay=0.02)'
     ];
 
     /* -------- live stats ------------------------------------------------- */

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -186,8 +186,8 @@
       'gotoXY()','setXY()','setXYrel()',
       'getL1()','getL2()','getL3()','getL4()',
       'grip()','release()',
-      'grip_smooth(end=50,step=1,delay=0.02)',
-      'release_smooth(end=180,step=1,delay=0.02)'
+      'grip_smooth(end_angle=50,step=1,delay=0.02)',
+      'release_smooth(end_angle=180,step=1,delay=0.02)'
     ];
 
     /* -------- live stats ------------------------------------------------- */

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -244,7 +244,7 @@
       const key = JSON.stringify({
         g:(info.gadgets||[]).map(g=>[g.id,g.class,g.calibrated]),
         b:(info.ball_details||[]).map(b=>b.id),
-        o:(info.markers||[]).filter(m=>m.type==='Obstacle').map(m=>m.id)
+        o:(info.markers||[]).filter(m=>m.type==='Obstacle').map(m=>m.index)
       });
       if(key!==lastClockKey){ lastClockKey=key; renderClocks(info); }
       updateActiveStyles(info);
@@ -293,7 +293,16 @@
             const o=document.createElement('option'); o.value='ball:'+ball.id; o.textContent='Ball '+ball.id.slice(0,4); objSel.appendChild(o);
           });
           (info.markers||[]).filter(m=>m.type==='Obstacle').forEach(m=>{
-            const o=document.createElement('option'); o.value='obs:'+m.id; o.textContent='Obs '+m.id; objSel.appendChild(o);
+            const o=document.createElement('option');
+            o.value='obs:'+ (m.index-1);
+            o.textContent=m.label||('Obs '+m.index);
+            objSel.appendChild(o);
+          });
+          (info.markers||[]).filter(m=>m.type==='PhysicalTarget').forEach(m=>{
+            const o=document.createElement('option');
+            o.value='tgt:'+ (m.index-1);
+            o.textContent=m.label||('Target '+m.index);
+            objSel.appendChild(o);
           });
           objSel.value=rec.obj||objSel.value;
           objSel.onchange=()=>{rec.obj=objSel.value;moveInputs[g.id]=rec;};

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -301,7 +301,7 @@
           (info.markers||[]).filter(m=>m.type==='PhysicalTarget').forEach(m=>{
             const o=document.createElement('option');
             o.value='tgt:'+ (m.index-1);
-            o.textContent=m.label||('Target '+m.index);
+            o.textContent=m.label||('P. Target '+m.index);
             objSel.appendChild(o);
           });
           objSel.value=rec.obj||objSel.value;


### PR DESCRIPTION
## Summary
- give each detected obstacle and physical target a unique label and index
- update `/move_object` route to reference obstacles and targets by index
- show these labels on the Flask UI for P0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68650e31de2c833389f59a1e94913b1c