### PR TITLE
Fix object selection persistence

### DIFF
--- a/ball_example/app.py
+++ b/ball_example/app.py
@@ -386,7 +386,8 @@ def move_manager_route():
     print(f"converted to mm=({x_mm:.2f},{y_mm:.2f})")
 
     print(f"sending manager move to ({x_mm:.2f}, {y_mm:.2f})")
-    manager.send_command(f"p.setXY({x_mm}, {y_mm})")
+    # use feedback-enhanced move for arena manager
+    manager.setXY_updated_manager(x_mm, y_mm)
     api.set_preview_target(device_id, (x_mm, y_mm))
     print("preview target set")
     return jsonify({"status": "ok", "x_mm": x_mm, "y_mm": y_mm})
@@ -396,15 +397,14 @@ def move_manager_route():
 def select_object_route():
     data = request.get_json(silent=True) or {}
     obj = data.get("object")
-    with api.lock:
-        if not obj:
-            api.set_selected_object(None)
-        else:
-            try:
-                obj_type, obj_id = obj.split(":", 1)
-                api.set_selected_object((obj_type, obj_id))
-            except Exception:
-                return jsonify({"status": "error", "message": "invalid"}), 400
+    if not obj:
+        api.set_selected_object(None)
+    else:
+        try:
+            obj_type, obj_id = obj.split(":", 1)
+            api.set_selected_object((obj_type, obj_id))
+        except Exception:
+            return jsonify({"status": "error", "message": "invalid"}), 400
     return jsonify({"status": "ok"})
 
 

--- a/ball_example/game_api.py
+++ b/ball_example/game_api.py
@@ -168,6 +168,8 @@ class GameAPI:
         for dev_id in finished_ids:
             self.stop_clock_mode(dev_id)
             self.clear_preview_target(dev_id)
+        if finished_ids and self.selected_obj is not None:
+            self.set_selected_object(None)
 
         with self.lock:
             preview = list(self.preview_targets.items())

--- a/ball_example/templates/index.html
+++ b/ball_example/templates/index.html
@@ -379,6 +379,10 @@
         });
         if(!g.calibrated) card.querySelectorAll('.btn').forEach(b=>b.disabled=true);
       }
+      if(selectedObj && !Object.values(active).includes('move_object')){
+        selectedObj=null;
+        fetch('/select_object',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({object:null})});
+      }
     }
 
     /* -------- autocomplete ----------------------------------------------- */


### PR DESCRIPTION
## Summary
- ensure manager moves always use feedback-based movement
- clear selected object when move scenario ends
- auto-clear selection in UI when no device is moving an object

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865b37c8ad483269e76e9bd2896c501