### PR TITLE
Ignore balls around markers and annotate tuning feed

### DIFF
--- a/ball_example/game_api.py
+++ b/ball_example/game_api.py
@@ -106,8 +106,9 @@ class GameAPI:
     # ------------------------------------------------------------------
     def _process_annotated(self, frame: np.ndarray) -> np.ndarray:
         mask = self.mask_pipe.get_masked_frame()
-        balls = self.tracker_mgr.update(frame, mask=mask)
         markers = ArucoDetector.detect(frame)
+        ignore = [m for m in markers if isinstance(m, (Obstacle, PhysicalTarget))]
+        balls = self.tracker_mgr.update(frame, mask=mask, ignore_markers=ignore)
 
         with self.lock:
             self.balls = balls

--- a/ball_example/templates/tune.html
+++ b/ball_example/templates/tune.html
@@ -15,7 +15,7 @@
 <body>
 <h3>Manual Detection Tuning</h3>
 <button id="mode-btn">Enable Manual Mode</button>
-<img id="video" src="{{ url_for('processed_feed') }}" alt="Processed">
+<img id="video" src="{{ url_for('balls_feed') }}" alt="Balls">
 <div class="slider">
 <label>Edge Density: <span id="edge_density_val"></span></label>
 <input id="edge_density" type="range" min="0" max="1" step="0.01">

--- a/ball_example/trackers.py
+++ b/ball_example/trackers.py
@@ -75,7 +75,12 @@ class BallTracker:
             self.missing[bid] = 0
 
 
-    def force_redetect(self, frame: np.ndarray, mask: Optional[np.ndarray] = None):
+    def force_redetect(
+        self,
+        frame: np.ndarray,
+        mask: Optional[np.ndarray] = None,
+        ignore_markers: Optional[List[ArucoMarker]] = None,
+    ):
         """Clear all state and redetect balls using current parameters."""
         with self.lock:
             self.trackers.clear()
@@ -83,7 +88,12 @@ class BallTracker:
             self.missing.clear()
             self.balls.clear()
             self.next_id = 0
-            for d in BallDetector.detect(frame, mask=mask, scale=DETECTION_SCALE):
+            for d in BallDetector.detect(
+                frame,
+                mask=mask,
+                scale=DETECTION_SCALE,
+                ignore_markers=ignore_markers,
+            ):
                 bid = f"ball_{self.next_id}"
                 self.next_id += 1
                 d.id = bid
@@ -93,13 +103,23 @@ class BallTracker:
 
 
     # ---------------- main update ----------------
-    def update(self, frame: np.ndarray, mask: Optional[np.ndarray] = None) -> List[Ball]:
+    def update(
+        self,
+        frame: np.ndarray,
+        mask: Optional[np.ndarray] = None,
+        ignore_markers: Optional[List[ArucoMarker]] = None,
+    ) -> List[Ball]:
         with self.lock:
             self.frame_count += 1
 
             # ------- if nothing tracked, detect now -------
             if not self.balls:
-                for d in BallDetector.detect(frame, mask=mask, scale=DETECTION_SCALE):
+                for d in BallDetector.detect(
+                    frame,
+                    mask=mask,
+                    scale=DETECTION_SCALE,
+                    ignore_markers=ignore_markers,
+                ):
                     bid = f"ball_{self.next_id}"
                     self.next_id += 1
                     d.id = bid
@@ -151,7 +171,12 @@ class BallTracker:
             self.balls = updates
 
             # ------- quick‑add new balls every frame ------
-            for d in BallDetector.detect(frame, mask=mask, scale=DETECTION_SCALE):
+            for d in BallDetector.detect(
+                frame,
+                mask=mask,
+                scale=DETECTION_SCALE,
+                ignore_markers=ignore_markers,
+            ):
                 # skip if near existing ball
                 if any(math.hypot(d.center[0] - b.center[0], d.center[1] - b.center[1]) < SPATIAL_THRESHOLD for b in self.balls.values()):
                     continue
@@ -176,7 +201,12 @@ class BallTracker:
             if self.frame_count >= REINIT_INTERVAL:
                 self.frame_count = 0
                 # run detection and merge with existing state (simple add if distinct)
-                for d in BallDetector.detect(frame, mask=mask, scale=DETECTION_SCALE):
+                for d in BallDetector.detect(
+                    frame,
+                    mask=mask,
+                    scale=DETECTION_SCALE,
+                    ignore_markers=ignore_markers,
+                ):
                     if any(math.hypot(d.center[0] - b.center[0], d.center[1] - b.center[1]) < SPATIAL_THRESHOLD for b in self.balls.values()):
                         continue
                     bid = f"ball_{self.next_id}"

--- a/docs/ball_example_usage.md
+++ b/docs/ball_example_usage.md
@@ -14,7 +14,7 @@ python ball_example/app.py
 
 By default the server listens on `{your_ip}:8000` and begins processing frames from camera index 0. The web interface served at `/` shows the live video with all detections overlaid. Also, `{your_ip}:8000/debug` shows information about detections and object properties.
 
-Note: `{your_ip}:8000/tune` shows a masked frame, which does NOT represent the one used for detecting balls.
+Note: `{your_ip}:8000/tune` now displays only the detected balls overlaid on the raw feed.
 
 The server exposes several endpoints used by the JavaScript front end (see `templates/` and `static/`). The most important ones are:
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -83,6 +83,11 @@ def test_processed_feed_route():
     r = client.get("/processed_feed")
     assert r.status_code == 200
 
+def test_balls_feed_route():
+    client = hockey_app.app.test_client()
+    r = client.get("/balls_feed")
+    assert r.status_code == 200
+
 
 def test_debug_endpoint():
     client = hockey_app.app.test_client()


### PR DESCRIPTION
## Summary
- filter out detected balls that contain obstacle or target ArUco markers
- pass ignore markers to tracker update and force re-detect routines
- create `/balls_feed` route streaming only ball annotations
- show this new feed on the tune page
- update usage docs and tests for new feed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866663d0a9c8333b68a777a0e4f4a57