### PR TITLE
Adjust ball detection around obstacles

### DIFF
--- a/ball_example/app.py
+++ b/ball_example/app.py
@@ -11,7 +11,7 @@ if __package__ in (None, ""):
 
 from .game_api import GameAPI
 from .scenario_loader import ScenarioLoadError
-from .detectors import BallDetector, compute_color_mask
+from .detectors import BallDetector, compute_color_mask, ArucoDetector
 from .trackers import DETECTION_SCALE
 from .models import ArucoWall, Arena, Obstacle, PhysicalTarget
 from .gadgets import ArenaManager, PlotClock
@@ -472,8 +472,9 @@ def manual_params_route():
         _apply_params(_manual_params)
         frame = api.raw_pipe.get_raw_frame()
         mask = compute_color_mask(frame, scale=DETECTION_SCALE) if frame is not None else None
+        markers = ArucoDetector.detect(frame) if frame is not None else []
         if frame is not None:
-            api.tracker_mgr.force_redetect(frame, mask=mask)
+            api.tracker_mgr.force_redetect(frame, mask=mask, markers=markers)
     return jsonify({"status": "ok"})
 
 
@@ -489,8 +490,9 @@ def manual_mode_route():
         _reset_defaults()
     frame = api.raw_pipe.get_raw_frame()
     mask = compute_color_mask(frame, scale=DETECTION_SCALE) if frame is not None else None
+    markers = ArucoDetector.detect(frame) if frame is not None else []
     if frame is not None:
-        api.tracker_mgr.force_redetect(frame, mask=mask)
+        api.tracker_mgr.force_redetect(frame, mask=mask, markers=markers)
     return jsonify({"status": "ok", "manual": manual_mode})
 
 

--- a/ball_example/app.py
+++ b/ball_example/app.py
@@ -9,13 +9,13 @@ if __package__ in (None, ""):
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
     __package__ = "ball_example"
 
-from .game_api import GameAPI
-from .scenario_loader import ScenarioLoadError
-from .detectors import BallDetector, compute_color_mask, ArucoDetector
-from .trackers import DETECTION_SCALE
-from .models import ArucoWall, Arena, Obstacle, PhysicalTarget
-from .gadgets import ArenaManager, PlotClock
-from high_level import calibrate_clocks, draw_arena
+from ball_example.game_api import GameAPI
+from ball_example.scenario_loader import ScenarioLoadError
+from ball_example.detectors import BallDetector, compute_color_mask, ArucoDetector
+from ball_example.trackers import DETECTION_SCALE
+from ball_example.models import ArucoWall, Arena, Obstacle, PhysicalTarget
+from ball_example.gadgets import ArenaManager, PlotClock
+from ball_example.high_level import calibrate_clocks, draw_arena
 
 app = Flask(__name__, template_folder="templates", static_folder="static")
 

--- a/ball_example/detectors.py
+++ b/ball_example/detectors.py
@@ -308,5 +308,27 @@ def compute_color_mask(frame: np.ndarray, scale: float = 0.5) -> np.ndarray:
     color_clean = cv2.morphologyEx(color_mask, cv2.MORPH_OPEN, kernel, iterations=1)
 
     return color_clean
+
+
+def filter_obstacle_overlaps(balls: List[Ball], markers: List[ArucoMarker]) -> List[Ball]:
+    """Return balls that do not overlap any obstacle marker."""
+    obstacles = [m for m in markers if isinstance(m, Obstacle)]
+    if not obstacles:
+        return balls
+    filtered: List[Ball] = []
+    for b in balls:
+        bx, by = b.center
+        r2 = b.radius * b.radius
+        reject = False
+        for obs in obstacles:
+            for px, py in obs.corners:
+                if (px - bx) ** 2 + (py - by) ** 2 <= r2:
+                    reject = True
+                    break
+            if reject:
+                break
+        if not reject:
+            filtered.append(b)
+    return filtered
         
-        
+       

--- a/ball_example/detectors.py
+++ b/ball_example/detectors.py
@@ -155,9 +155,15 @@ class BallDetector:
         max_radius_s = int(max_radius * scale)
 
         balls: List[Ball] = []
-        obstacles: List[Obstacle] = []
+        # Both obstacle markers and physical targets are ignored when
+        # they fall inside a detected circle.
+        obstacles: List[Obstacle | PhysicalTarget] = []
         if markers:
-            obstacles = [m for m in markers if isinstance(m, Obstacle)]
+            obstacles = [
+                m
+                for m in markers
+                if isinstance(m, (Obstacle, PhysicalTarget))
+            ]
 
         def overlaps_obstacle(cx: int, cy: int, r: int) -> bool:
             if not obstacles:

--- a/ball_example/game_api.py
+++ b/ball_example/game_api.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from .camera import Camera
 from .trackers import BallTracker, DETECTION_SCALE
-from .detectors import ArucoDetector, BallDetector, filter_obstacle_overlaps
+from .detectors import ArucoDetector, BallDetector
 from .pipelines import RawImagePipeline, AnnotatedImagePipeline
 from .renderers import render_overlay, draw_line
 from .models import Ball, ArucoMarker, ArucoHitter, ArucoManager, Obstacle
@@ -101,9 +101,8 @@ class GameAPI:
 
     # ------------------------------------------------------------------
     def _process_annotated(self, frame: np.ndarray) -> np.ndarray:
-        balls = self.tracker_mgr.update(frame, mask=None)
         markers = ArucoDetector.detect(frame)
-        balls = filter_obstacle_overlaps(balls, markers)
+        balls = self.tracker_mgr.update(frame, mask=None, markers=markers)
 
         with self.lock:
             self.balls = balls

--- a/ball_example/templates/tune.html
+++ b/ball_example/templates/tune.html
@@ -15,7 +15,7 @@
 <body>
 <h3>Manual Detection Tuning</h3>
 <button id="mode-btn">Enable Manual Mode</button>
-<img id="video" src="{{ url_for('processed_feed') }}" alt="Processed">
+<img id="video" src="{{ url_for('video_feed') }}" alt="Video">
 <div class="slider">
 <label>Edge Density: <span id="edge_density_val"></span></label>
 <input id="edge_density" type="range" min="0" max="1" step="0.01">


### PR DESCRIPTION
## Summary
- discard balls overlapping obstacles
- remove MaskedImagePipeline usage and show annotated frames on tune page
- compute masks directly for manual redetection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68666d1972288333bf8b7c3be7eb3f3e